### PR TITLE
Proxy entry for client-config.js endpoint in webpack dev mode

### DIFF
--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -62,6 +62,13 @@ const delayedConf = new Promise(function(resolve) {
         '/v2'
       ],
       target: 'https://localhost/'
+    }, {
+      ...proxyCommonConf,
+      pathRewrite: { '^/shogun-boot/client-config.js': '' },
+      context: [
+        '/shogun-boot/client-config.js',
+      ],
+      target: 'https://localhost/admin/client-config.js'
     }]
   };
   const loginUrl = `https://${keycloakHost}/auth/realms/SpringBootKeycloak/protocol/openid-connect/token`;


### PR DESCRIPTION
Adds proxy for `client-config.js` served by shogun-boot backend while running in webpack dev mode.

This way, there is no need any more to adapt `fallbackConfig.js` in dev mode if the "real" config exists.

Please review @terrestris/devs 