### PR TITLE
Configurable application root path

### DIFF
--- a/assets/fallbackConfig.js
+++ b/assets/fallbackConfig.js
@@ -1,4 +1,5 @@
 var shogunApplicationConfig = {
+  appPrefix: '',
   path: {
     base: 'http://localhost:8080',
     swagger: '/shogun-boot/v2/api-docs',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,8 @@ import Logger from 'js-logger';
 import { appInfoAtom, userInfoAtom } from './State/atoms';
 import { setSwaggerDocs } from './State/static';
 
+import config from 'shogunApplicationConfig';
+
 const userService = new UserService();
 
 const App: React.FC = props => {
@@ -96,13 +98,13 @@ const App: React.FC = props => {
       >
         <Switch>
           <Route
-            path="/portal"
+            path={`${config.appPrefix}/portal`}
             component={Portal}
           />
           <Redirect
             exact
-            from="/"
-            to="/portal"
+            from={`${config.appPrefix}/`}
+            to={`${config.appPrefix}/portal`}
           />
         </Switch>
       </React.Suspense>

--- a/src/Component/Application/ApplicationEditForm/ApplicationEditForm.tsx
+++ b/src/Component/Application/ApplicationEditForm/ApplicationEditForm.tsx
@@ -4,7 +4,6 @@ import Application from '../../../Model/Application';
 
 import { Button, Checkbox, Form, Input, Modal, notification } from 'antd';
 
-
 import './ApplicationEditForm.less';
 import ApplicationService from '../../../Service/ApplicationService/ApplicationService';
 import Logger from 'js-logger';
@@ -12,6 +11,8 @@ import Logger from 'js-logger';
 import { useHistory } from 'react-router-dom';
 import JSONEditor from '../../FormField/JSONEditor/JSONEditor';
 import DisplayField from '../../FormField/DisplayField/DisplayField';
+
+import config from 'shogunApplicationConfig';
 
 type OwnProps = {
   id?: number | 'create';
@@ -74,7 +75,7 @@ export const ApplicationEditForm: React.FC<ApplicationEditFormProps> = ({
                   message: 'Applikation gelöscht',
                   description: `Applikation "${appName}" wurde gelöscht`
                 });
-                history.push('/portal/application');
+                history.push(`${config.appPrefix}/portal/application`);
               });
           }
         } catch (error) {

--- a/src/Component/Application/ApplicationRoot/ApplicationRoot.tsx
+++ b/src/Component/Application/ApplicationRoot/ApplicationRoot.tsx
@@ -10,6 +10,8 @@ import {
 import ApplicationEditForm from '../ApplicationEditForm/ApplicationEditForm';
 import ApplicationTable from '../ApplicationTable/ApplicationTable';
 
+import config from 'shogunApplicationConfig';
+
 import './ApplicationRoot.less';
 
 interface OwnProps { }
@@ -23,7 +25,7 @@ export const ApplicationRoot: React.FC<ApplicationProps> = props => {
   const history = useHistory();
   const location = useLocation();
   const match = matchPath<{ applicationId: string }>(location.pathname, {
-    path: '/portal/application/:applicationId'
+    path: `${config.appPrefix}/portal/application/:applicationId`
   });
   const applicationId = match?.params?.applicationId;
 
@@ -47,7 +49,7 @@ export const ApplicationRoot: React.FC<ApplicationProps> = props => {
         title="Applikationen"
         subTitle="… die die Welt verändern"
         extra={[
-          <Link key="create" to="/portal/application/create">
+          <Link key="create" to={`${config.appPrefix}/portal/application/create`}>
             <Button type="primary">
               Applikation anlegen
             </Button>

--- a/src/Component/Application/ApplicationTable/ApplicationTable.tsx
+++ b/src/Component/Application/ApplicationTable/ApplicationTable.tsx
@@ -4,6 +4,8 @@ import { EntityTable, EntityTableProps } from '../../../Component/Table/EntityTa
 import ApplicationService from '../../../Service/ApplicationService/ApplicationService';
 import TableUtil from '../../../Util/TableUtil';
 
+import config from 'shogunApplicationConfig';
+
 interface OwnProps { }
 
 type ApplicationTableProps = OwnProps & Omit<EntityTableProps, 'service' | 'routePath' | 'name' | 'columns' >;
@@ -26,7 +28,7 @@ export const ApplicationTable: React.FC<ApplicationTableProps> = props => {
   return (
     <EntityTable
       service={applicationService}
-      routePath={'/portal/application'}
+      routePath={`${config.appPrefix}/portal/application`}
       name={{
         singular: 'Applikation',
         plural: 'Applilkationen'

--- a/src/Component/Header/Header.tsx
+++ b/src/Component/Header/Header.tsx
@@ -5,6 +5,8 @@ import { Link } from 'react-router-dom';
 import logo from '../../../assets/img/shogun_logo.png';
 import User from '../Menu/User/User';
 
+import config from 'shogunApplicationConfig';
+
 import './Header.less';
 
 interface OwnProps {
@@ -21,7 +23,7 @@ export const Header: React.FC<HeaderProps> = props => {
         className="page-header"
         title={
           <Link
-            to={'/portal'}
+            to={`${config.appPrefix}/portal`}
             className="header-logo-a"
           >
             <img

--- a/src/Component/ImageFile/ImageFileEditForm/ImageFileEditForm.tsx
+++ b/src/Component/ImageFile/ImageFileEditForm/ImageFileEditForm.tsx
@@ -2,13 +2,14 @@ import React, { useEffect, useState } from 'react';
 
 import { Button, Form, Input, Modal, notification } from 'antd';
 
-
 import './ImageFileEditForm.less';
 import ImageFileService from '../../../Service/ImageFileService/ImageFileService';
 import Logger from 'js-logger';
 
 import { useHistory } from 'react-router-dom';
 import ImageFile from '../../../Model/ImageFile';
+
+import config from 'shogunApplicationConfig';
 
 type OwnProps = {
   id?: number | 'create';
@@ -71,7 +72,7 @@ export const ImageFileEditForm: React.FC<ImageFileEditFormProps> = ({
                   message: 'Bilddatei gelöscht',
                   description: `Bilddatei "${imageFileName}" wurde gelöscht`
                 });
-                history.push('/portal/imagefile');
+                history.push(`${config.appPrefix}/portal/imagefile`);
               });
           }
         } catch (error) {

--- a/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.tsx
+++ b/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.tsx
@@ -24,7 +24,7 @@ export const ImageFileRoot: React.FC<ImageFileRootProps> = props => {
   const history = useHistory();
   const location = useLocation();
   const match = matchPath<{ uuid: string }>(location.pathname, {
-    path: '/portal/imagefile/:uuid'
+    path: `${config.appPrefix}/portal/imagefile/:uuid`
   });
   const imageFileUuid = match?.params?.uuid;
 
@@ -44,7 +44,7 @@ export const ImageFileRoot: React.FC<ImageFileRootProps> = props => {
         title="Bilddateien"
         subTitle="… die die Welt zeigen"
         extra={[
-          <Link key="create" to="/portal/imagefile/create">
+          <Link key="create" to={`${config.appPrefix}/portal/imagefile/create`}>
             <Button type="primary">
               Bilddatei hochladen
             </Button>

--- a/src/Component/ImageFile/ImageFileTable/ImageFileTable.tsx
+++ b/src/Component/ImageFile/ImageFileTable/ImageFileTable.tsx
@@ -6,6 +6,8 @@ import ImageFile from '../../../Model/ImageFile';
 import ImageFileService from '../../../Service/ImageFileService/ImageFileService';
 import TableUtil from '../../../Util/TableUtil';
 
+import config from 'shogunApplicationConfig';
+
 interface OwnProps { }
 
 type ImageFileTableProps = OwnProps & Omit<EntityTableProps, 'service' | 'routePath' | 'name' | 'columns' >;
@@ -35,13 +37,13 @@ export const ImageFileTable: React.FC<ImageFileTableProps> = props => {
 
   const history = useHistory();
   const onRowClick = (imageFile: ImageFile) => {
-    history.push(`/portal/imagefile/${imageFile.fileUuid}`);
+    history.push(`${config.appPrefix}/portal/imagefile/${imageFile.fileUuid}`);
   };
 
   return (
     <EntityTable
       service={imageFileService}
-      routePath={'/portal/imagefile'}
+      routePath={`${config.appPrefix}/portal/imagefile`}
       onRowClick={onRowClick}
       name={{
         singular: 'Bilddatei',

--- a/src/Component/Layer/LayerRoot/LayerRoot.tsx
+++ b/src/Component/Layer/LayerRoot/LayerRoot.tsx
@@ -9,6 +9,8 @@ import {
 
 import LayerTable from '../LayerTable/LayerTable';
 
+import config from 'shogunApplicationConfig';
+
 import './LayerRoot.less';
 
 interface OwnProps { }
@@ -22,7 +24,7 @@ export const LayerRoot: React.FC<LayerRootProps> = props => {
   const history = useHistory();
   const location = useLocation();
   const match = matchPath<{layerId: string}>(location.pathname, {
-    path: '/portal/layer/:layerId'
+    path: `${config.appPrefix}/portal/layer/:layerId`
   });
   const layerId = match?.params?.layerId;
 
@@ -45,7 +47,7 @@ export const LayerRoot: React.FC<LayerRootProps> = props => {
         title="Themen"
         subTitle="… die die Welt bewegen"
         extra={[
-          <Link key="create" to="/portal/layer/create">
+          <Link key="create" to={`${config.appPrefix}/portal/layer/create`}>
             <Button type="primary">
               Layer anlegen
             </Button>

--- a/src/Component/Layer/LayerTable/LayerTable.tsx
+++ b/src/Component/Layer/LayerTable/LayerTable.tsx
@@ -4,6 +4,8 @@ import { EntityTable, EntityTableProps } from '../../../Component/Table/EntityTa
 import LayerService from '../../../Service/LayerSerivce/LayerService';
 import TableUtil from '../../../Util/TableUtil';
 
+import config from 'shogunApplicationConfig';
+
 interface OwnProps { }
 
 type LayerTableProps = OwnProps & Omit<EntityTableProps, 'service' | 'routePath' | 'name' | 'columns' >;
@@ -35,7 +37,7 @@ export const LayerTable: React.FC<LayerTableProps> = props => {
   return (
     <EntityTable
       service={layerService}
-      routePath={'/portal/layer'}
+      routePath={`${config.appPrefix}/portal/layer`}
       name={{
         singular: 'Thema',
         plural: 'Themen'

--- a/src/Component/Menu/Navigation/Navigation.tsx
+++ b/src/Component/Menu/Navigation/Navigation.tsx
@@ -12,6 +12,8 @@ import {
   Menu
 } from 'antd';
 
+import config from 'shogunApplicationConfig';
+
 interface OwnProps {
   collapsed?: boolean;
 }
@@ -27,11 +29,11 @@ export const Navigation: React.FC<NavigationProps> = (props) => {
   } = props;
 
   const onSelect = ({ key }) => {
-    history.push(`/portal/${key}`);
+    history.push(`${config.appPrefix}/portal/${key}`);
   };
 
   const match = matchPath<{activeKey: string}>(location.pathname, {
-    path: '/portal/:activeKey'
+    path: `${config.appPrefix}/portal/:activeKey`
   });
   const activeKey = match?.params?.activeKey;
 

--- a/src/Component/User/UserRoot/UserRoot.tsx
+++ b/src/Component/User/UserRoot/UserRoot.tsx
@@ -9,6 +9,8 @@ import {
 
 import UserTable from '../UserTable/UserTable';
 
+import config from 'shogunApplicationConfig';
+
 import './UserRoot.less';
 
 interface OwnProps { }
@@ -22,7 +24,7 @@ export const UserRoot: React.FC<UserRootProps> = props => {
   const history = useHistory();
   const location = useLocation();
   const match = matchPath<{userId: string}>(location.pathname, {
-    path: '/portal/layer/:userId'
+    path: `${config.appPrefix}/portal/layer/:userId`
   });
   const userId = match?.params?.userId;
 
@@ -45,7 +47,7 @@ export const UserRoot: React.FC<UserRootProps> = props => {
         title="User"
         subTitle="… die die Welt verbessern"
         extra={[
-          <Link key="create" to="/portal/user/create">
+          <Link key="create" to={`${config.appPrefix}/portal/user/create`}>
             <Button type="primary">
               User anlegen
             </Button>

--- a/src/Component/User/UserTable/UserTable.tsx
+++ b/src/Component/User/UserTable/UserTable.tsx
@@ -4,6 +4,8 @@ import UserService from '../../../Service/UserService/UserService';
 import { EntityTable, EntityTableProps } from '../../../Component/Table/EntityTable/EntityTable';
 import TableUtil from '../../../Util/TableUtil';
 
+import config from 'shogunApplicationConfig';
+
 interface OwnProps { }
 
 type UserTableProps = OwnProps & Omit<EntityTableProps, 'service' | 'routePath' | 'name' | 'columns' >;
@@ -43,7 +45,7 @@ export const UserTable: React.FC<UserTableProps> = props => {
   return (
     <EntityTable
       service={userService}
-      routePath={'/portal/user'}
+      routePath={`${config.appPrefix}/portal/user`}
       name={{
         singular: 'Nutzer',
         plural: 'Nutzer'

--- a/src/Component/WelcomeDashboard/WelcomeDashboard.tsx
+++ b/src/Component/WelcomeDashboard/WelcomeDashboard.tsx
@@ -21,6 +21,8 @@ import Avatar from 'antd/lib/avatar/avatar';
 import LayerTable from '../Layer/LayerTable/LayerTable';
 import UserTable from '../User/UserTable/UserTable';
 
+import config from 'shogunApplicationConfig';
+
 type WelcomeDashboardProps = {};
 
 export const WelcomeDashboard: React.FC<WelcomeDashboardProps> = (props) => {
@@ -70,33 +72,33 @@ export const WelcomeDashboard: React.FC<WelcomeDashboardProps> = (props) => {
       </DashboardCard>
       <DashboardCard
         className="application-dashboard-card"
-        title={<Link to={'/portal/logs'}>Logs</Link>}
+        title={<Link to={`${config.appPrefix}/portal/logs`}>Logs</Link>}
         description="… die die Welt erklären"
-        avatar={<Link to={'/portal/logs'}><UnorderedListOutlined /></Link>}
+        avatar={<Link to={`${config.appPrefix}/portal/logs`}><UnorderedListOutlined /></Link>}
       >
         {/* <UserProfileForm /> */}
       </DashboardCard>
       <DashboardCard
         className="application-dashboard-card"
-        title={<Link to={'/portal/application'}>Applikationen</Link>}
+        title={<Link to={`${config.appPrefix}/portal/application`}>Applikationen</Link>}
         description="… die die Welt verändern"
-        avatar={<Link to={'/portal/application'}><BankOutlined /></Link>}
+        avatar={<Link to={`${config.appPrefix}/portal/application`}><BankOutlined /></Link>}
       >
         <ApplicationTable />
       </DashboardCard>
       <DashboardCard
         className="layer-dashboard-card"
-        title={<Link to={'/portal/layer'}>Themen</Link>}
+        title={<Link to={`${config.appPrefix}/portal/layer`}>Themen</Link>}
         description="… die die Welt bewegen"
-        avatar={<Link to={'/portal/layer'}><AppstoreOutlined /></Link>}
+        avatar={<Link to={`${config.appPrefix}/portal/layer`}><AppstoreOutlined /></Link>}
       >
         <LayerTable />
       </DashboardCard>
       <DashboardCard
         className="layer-dashboard-card"
-        title={<Link to={'/portal/user'}>User</Link>}
+        title={<Link to={`${config.appPrefix}/portal/user`}>User</Link>}
         description="… die die Welt verbessern"
-        avatar={<Link to={'/portal/user'}><UserOutlined /></Link>}
+        avatar={<Link to={`${config.appPrefix}/portal/user`}><UserOutlined /></Link>}
       >
         <UserTable />
       </DashboardCard>

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -19,6 +19,8 @@ import './Portal.less';
 import UserRoot from '../../Component/User/UserRoot/UserRoot';
 import ImageFileRoot from '../../Component/ImageFile/ImageFileRoot/ImageFileRoot';
 
+import config from 'shogunApplicationConfig';
+
 interface OwnProps { }
 
 type PortalProps = OwnProps;
@@ -45,19 +47,19 @@ export const Portal: React.FC<PortalProps> = props => {
       <div className="content">
         <Switch>
           <Route
-            path="/portal/application"
+            path={`${config.appPrefix}/portal/application`}
             component={ApplicationRoot}
           />
           <Route
-            path="/portal/layer"
+            path={`${config.appPrefix}/portal/layer`}
             component={LayerRoot}
           />
           <Route
-            path="/portal/user"
+            path={`${config.appPrefix}/portal/user`}
             component={UserRoot}
           />
           <Route
-            path="/portal/imagefile"
+            path={`${config.appPrefix}/portal/imagefile`}
             component={ImageFileRoot}
           />
           <Route


### PR DESCRIPTION
This suggests to introduce a new config named `appPrefix` to override the app base path the admin is served on. This is needed for all routing handlers as soon as the admin is served under a non-root path, e.g. `https://localhost/myadmin`.

Please review @terrestris/devs.