### PR TITLE
Add menu entry showing assorted server metrics

### DIFF
--- a/assets/fallbackConfig.js
+++ b/assets/fallbackConfig.js
@@ -20,7 +20,8 @@ var shogunApplicationConfig = {
     },
     loggers: '/actuator/loggers',
     logfile: '/actuator/logfile',
-    logo: null
+    logo: null,
+    metrics: '/actuator/metrics'
   },
   models: [
     'Layer',
@@ -60,6 +61,9 @@ var shogunApplicationConfig = {
       }
     },
     status: {
+      metrics: {
+        visible: true
+      },
       logs: {
         visible: true
       }

--- a/src/Component/Menu/Navigation/Navigation.tsx
+++ b/src/Component/Menu/Navigation/Navigation.tsx
@@ -6,7 +6,8 @@ import {
   AppstoreOutlined,
   UserOutlined,
   FileImageOutlined,
-  FileTextOutlined
+  FileTextOutlined,
+  BarChartOutlined
 } from '@ant-design/icons';
 
 import {
@@ -98,6 +99,15 @@ export const Navigation: React.FC<NavigationProps> = (props) => {
         title="Status"
       >
         {
+          navigationConf?.status?.metrics?.visible &&
+            <Menu.Item
+              key="status/metrics"
+            >
+              <BarChartOutlined />
+              <span>Metriken</span>
+            </Menu.Item>
+        }
+        {
           navigationConf?.status?.logs?.visible &&
             <Menu.Item
               key="status/logs"
@@ -106,7 +116,6 @@ export const Navigation: React.FC<NavigationProps> = (props) => {
               <span>Logs</span>
             </Menu.Item>
         }
-
       </Menu.SubMenu>
       <Menu.SubMenu
         key="settings"

--- a/src/Component/Metrics/JdbcConnectionsActive/JdbcConnectionsActive.tsx
+++ b/src/Component/Metrics/JdbcConnectionsActive/JdbcConnectionsActive.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface JdbcConnectionsActiveProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const JdbcConnectionsActive: React.FC<JdbcConnectionsActiveProps> = ({
+  ...passThroughProps
+}) => {
+
+  return (
+    <MetricEntry
+      type="jdbc.connections.active"
+      {...passThroughProps}
+    />
+  );
+};
+
+export default JdbcConnectionsActive;

--- a/src/Component/Metrics/JvmMemoryUsed/JvmMemoryUsed.tsx
+++ b/src/Component/Metrics/JvmMemoryUsed/JvmMemoryUsed.tsx
@@ -1,0 +1,33 @@
+import React, { ReactNode } from 'react';
+
+import { Metric } from '../../../Service/MetricService/MetricService';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface JvmMemoryUsedProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const JvmMemoryUsed: React.FC<JvmMemoryUsedProps> = ({
+  ...passThroughProps
+}) => {
+
+  const valueRenderer = (value: number | string, metric: Metric): ReactNode => {
+    let val = Number(value) * (9.537 * Math.pow(10, -7));
+
+    return <span>{val.toFixed(2)}</span>;
+  }
+
+  const suffixRenderer = (): ReactNode => {
+    return <span>MB</span>;
+  }
+
+  return (
+    <MetricEntry
+      type="jvm.memory.used"
+      valueRenderer={valueRenderer}
+      suffixRenderer={suffixRenderer}
+      {...passThroughProps}
+    />
+  );
+};
+
+export default JvmMemoryUsed;

--- a/src/Component/Metrics/JvmThreadsLive/JvmThreadsLive.tsx
+++ b/src/Component/Metrics/JvmThreadsLive/JvmThreadsLive.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface JvmThreadsLiveProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const JvmThreadsLive: React.FC<JvmThreadsLiveProps> = ({
+  ...passThroughProps
+}) => {
+
+  return (
+    <MetricEntry
+      type="jvm.threads.live"
+      {...passThroughProps}
+    />
+  );
+};
+
+export default JvmThreadsLive;

--- a/src/Component/Metrics/MetricEntry/MetricEntry.tsx
+++ b/src/Component/Metrics/MetricEntry/MetricEntry.tsx
@@ -1,0 +1,129 @@
+import React, {
+  ReactNode,
+  useEffect,
+  useState
+} from 'react';
+
+import {
+  Button,
+  Card,
+  Statistic,
+  Tooltip
+} from 'antd';
+import { StatisticProps } from 'antd/lib/statistic/Statistic';
+
+import { ReloadOutlined } from '@ant-design/icons';
+
+import isFunction from 'lodash/isFunction';
+
+import MetricService, { Metric } from '../../../Service/MetricService/MetricService';
+
+const metricService = new MetricService();
+
+type StatisticPropExcludes = 'value' | 'prefix' | 'suffix' | 'title' | 'formatter';
+
+export interface MetricEntryProps extends Omit<StatisticProps, StatisticPropExcludes> {
+  type: string;
+  prefixRenderer?: (metric: Metric) => ReactNode;
+  suffixRenderer?: (metric: Metric) => ReactNode;
+  titleRenderer?: (metric: Metric) => ReactNode;
+  valueRenderer?: (value: number | string, metric: Metric) => ReactNode;
+};
+
+export const MetricEntry: React.FC<MetricEntryProps> = ({
+  type,
+  prefixRenderer,
+  suffixRenderer,
+  titleRenderer,
+  valueRenderer,
+  ...passThroughProps
+}) => {
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [metric, setMetric] = useState<Metric>();
+
+  useEffect(() => {
+    fetchMetric();
+  }, []);
+
+  const fetchMetric = async () => {
+    setIsLoading(true);
+
+    const metricResponse = await metricService.getMetric(type);
+
+    setMetric(metricResponse);
+
+    setIsLoading(false);
+  };
+
+  const getPrefix = (): ReactNode => {
+    if (isFunction(prefixRenderer)) {
+      return prefixRenderer(metric);
+    }
+
+    return null;
+  };
+
+  const getSuffix = (): ReactNode => {
+    if (isFunction(suffixRenderer)) {
+      return suffixRenderer(metric);
+    }
+
+    return null;
+  };
+
+  const getTitle = (): ReactNode => {
+    if (isFunction(titleRenderer)) {
+      return titleRenderer(metric);
+    }
+
+    return (
+      <Tooltip
+        title={metric?.description}
+      >
+        <span>{metric?.description}</span>
+      </Tooltip>
+    );
+  }
+
+  const getFormatter = (value: number | string): ReactNode => {
+    if (isFunction(valueRenderer)) {
+      return valueRenderer(value, metric);
+    }
+
+    return value;
+  }
+
+  return (
+    <Card
+      loading={isLoading}
+      actions={[
+        <Tooltip
+          title="Reload"
+          mouseEnterDelay={0.5}
+        >
+          <Button
+            onClick={fetchMetric}
+          >
+            <ReloadOutlined />
+          </Button>
+        </Tooltip>
+      ]}
+    >
+      <Statistic
+        value={metric?.measurements[0]?.value}
+        prefix={getPrefix()}
+        suffix={getSuffix()}
+        title={getTitle()}
+        formatter={getFormatter}
+        valueStyle={{
+          color: '#3f8600'
+        }}
+        {...passThroughProps}
+      />
+    </Card>
+  );
+};
+
+
+export default MetricEntry;

--- a/src/Component/Metrics/MetricsRoot/MetricsRoot.less
+++ b/src/Component/Metrics/MetricsRoot/MetricsRoot.less
@@ -1,0 +1,3 @@
+.metrics-card-container {
+  padding: 15px;
+}

--- a/src/Component/Metrics/MetricsRoot/MetricsRoot.tsx
+++ b/src/Component/Metrics/MetricsRoot/MetricsRoot.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+import { useHistory } from 'react-router-dom';
+
+import {
+  Col,
+  PageHeader,
+  Row
+} from 'antd';
+
+import ProcessUptime from '../ProcessUptime/ProcessUptime';
+import JdbcConnectionsActive from '../JdbcConnectionsActive/JdbcConnectionsActive';
+import JvmMemoryUsed from '../JvmMemoryUsed/JvmMemoryUsed';
+import JvmThreadsLive from '../JvmThreadsLive/JvmThreadsLive';
+import ProcessCpuUsage from '../ProcessCpuUsage/ProcessCpuUsage';
+import SystemCpuCount from '../SystemCpuCount/SystemCpuCount';
+import SystemCpuUsage from '../SystemCpuUsage/SystemCpuUsage';
+import ProcessStartTime from '../ProcessStartTime/ProcessStartTime';
+import SystemLoadAverage from '../SystemLoadAverage/SystemLoadAverage';
+
+import './MetricsRoot.less';
+
+type MetricsRootProps = {};
+
+/**
+ * TODO Ideas:
+ *
+ *  * show link to swagger and graphql
+ *  * show link to all other services (e.g. GeoServer) including status (crossing light)
+ *
+ */
+
+export const MetricsRoot: React.FC<MetricsRootProps> = (props) => {
+
+  const history = useHistory();
+
+  return (
+    <div
+      className="metrics-root"
+    >
+      <PageHeader
+        className="header"
+        onBack={() => history.goBack()}
+        title="Metriken"
+        subTitle="… die die Welt vermessen"
+      />
+      <div className="metrics-card-container">
+        <Row gutter={[16, 16]}>
+          <Col span={8}>
+            <JdbcConnectionsActive />
+          </Col>
+          <Col span={8}>
+            <JvmThreadsLive />
+          </Col>
+          <Col span={8}>
+            <JvmMemoryUsed />
+          </Col>
+        </Row>
+        <Row gutter={[16, 16]}>
+          <Col span={8}>
+            <ProcessCpuUsage />
+          </Col>
+          <Col span={8}>
+            <SystemCpuCount />
+          </Col>
+          <Col span={8}>
+            <SystemCpuUsage />
+          </Col>
+        </Row>
+        <Row gutter={[16, 16]}>
+          <Col span={8}>
+            <ProcessStartTime />
+          </Col>
+          <Col span={8}>
+            <ProcessUptime />
+          </Col>
+          <Col span={8}>
+            <SystemLoadAverage />
+          </Col>
+        </Row>
+      </div>
+    </div>
+  );
+};
+
+export default MetricsRoot;

--- a/src/Component/Metrics/ProcessCpuUsage/ProcessCpuUsage.tsx
+++ b/src/Component/Metrics/ProcessCpuUsage/ProcessCpuUsage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface ProcessCpuUsageProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const ProcessCpuUsage: React.FC<ProcessCpuUsageProps> = ({
+  ...passThroughProps
+}) => {
+
+  return (
+    <MetricEntry
+      type="process.cpu.usage"
+      {...passThroughProps}
+    />
+  );
+};
+
+export default ProcessCpuUsage;

--- a/src/Component/Metrics/ProcessStartTime/ProcessStartTime.tsx
+++ b/src/Component/Metrics/ProcessStartTime/ProcessStartTime.tsx
@@ -1,0 +1,30 @@
+import React, {
+  ReactNode,
+} from 'react';
+
+import moment from 'moment';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface ProcessStartTimeProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const ProcessStartTime: React.FC<ProcessStartTimeProps> = ({
+  ...passThroughProps
+}) => {
+
+  const valueRenderer = (value: number | string): ReactNode => {
+    let val = moment(Number(value) * 1000).format('llll');
+
+    return <span>{val}</span>;
+  }
+
+  return (
+    <MetricEntry
+      type="process.start.time"
+      valueRenderer={valueRenderer}
+      {...passThroughProps}
+    />
+  );
+};
+
+export default ProcessStartTime;

--- a/src/Component/Metrics/ProcessUptime/ProcessUptime.tsx
+++ b/src/Component/Metrics/ProcessUptime/ProcessUptime.tsx
@@ -1,0 +1,35 @@
+import React, {
+  ReactNode,
+} from 'react';
+
+import moment from 'moment';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface ProcessUptimeProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const ProcessUptime: React.FC<ProcessUptimeProps> = ({
+  ...passThroughProps
+}) => {
+
+  const valueRenderer = (value: number | string): ReactNode => {
+    let val = moment.utc(Number(value) * 1000).format('HH:mm:ss');
+
+    return <span>{val}</span>;
+  }
+
+  const suffixRenderer = () => {
+    return <span>HH:mm:ss</span>;
+  };
+
+  return (
+    <MetricEntry
+      type="process.uptime"
+      valueRenderer={valueRenderer}
+      suffixRenderer={suffixRenderer}
+      {...passThroughProps}
+    />
+  );
+};
+
+export default ProcessUptime;

--- a/src/Component/Metrics/SystemCpuCount/SystemCpuCount.tsx
+++ b/src/Component/Metrics/SystemCpuCount/SystemCpuCount.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface SystemCpuCountProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const SystemCpuCount: React.FC<SystemCpuCountProps> = ({
+  ...passThroughProps
+}) => {
+
+  return (
+    <MetricEntry
+      type="system.cpu.count"
+      {...passThroughProps}
+    />
+  );
+};
+
+export default SystemCpuCount;

--- a/src/Component/Metrics/SystemCpuUsage/SystemCpuUsage.tsx
+++ b/src/Component/Metrics/SystemCpuUsage/SystemCpuUsage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface SystemCpuUsageProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const SystemCpuUsage: React.FC<SystemCpuUsageProps> = ({
+  ...passThroughProps
+}) => {
+
+  return (
+    <MetricEntry
+      type="system.cpu.usage"
+      {...passThroughProps}
+    />
+  );
+};
+
+export default SystemCpuUsage;

--- a/src/Component/Metrics/SystemLoadAverage/SystemLoadAverage.tsx
+++ b/src/Component/Metrics/SystemLoadAverage/SystemLoadAverage.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import MetricEntry, { MetricEntryProps } from '../MetricEntry/MetricEntry';
+
+interface SystemLoadAverageProps extends Omit<MetricEntryProps, 'type'> { };
+
+export const SystemLoadAverage: React.FC<SystemLoadAverageProps> = ({
+  ...passThroughProps
+}) => {
+
+  return (
+    <MetricEntry
+      type="system.load.average.1m"
+      {...passThroughProps}
+    />
+  );
+};
+
+export default SystemLoadAverage;

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -19,6 +19,7 @@ import UserRoot from '../../Component/User/UserRoot/UserRoot';
 import ImageFileRoot from '../../Component/ImageFile/ImageFileRoot/ImageFileRoot';
 import Logs from '../../Component/Logs/Logs';
 import LogSettingsRoot from '../../Component/LogSettings/LogSettingsRoot/LogSettingsRoot';
+import MetricsRoot from '../../Component/Metrics/MetricsRoot/MetricsRoot';
 
 import config from 'shogunApplicationConfig';
 
@@ -64,6 +65,10 @@ export const Portal: React.FC<PortalProps> = props => {
           <Route
             path={`${config.appPrefix}/portal/imagefile`}
             component={ImageFileRoot}
+          />
+          <Route
+            path={`${config.appPrefix}/portal/status/metrics`}
+            component={MetricsRoot}
           />
           <Route
             path={`${config.appPrefix}/portal/status/logs`}

--- a/src/Service/MetricService/MetricService.ts
+++ b/src/Service/MetricService/MetricService.ts
@@ -1,0 +1,44 @@
+import Logger from '../../Logger';
+
+import config from 'shogunApplicationConfig';
+
+export type Statistic = {
+  statistic: string;
+  value: number | string
+}
+
+export type Tag = {
+  tag: string;
+  values: string[]
+}
+
+export type BaseUnit = 'seconds' | 'events' | 'threads' | 'bytes';
+
+export type Metric = {
+  name: string;
+  description: string;
+  baseUnit: BaseUnit;
+  measurements: Statistic[];
+  availableTags: Tag[];
+};
+
+class MetricService {
+
+  constructor() {}
+
+  async getMetric(type: string): Promise<Metric> {
+    try {
+      const response = await fetch(`${config.path.metrics}/${type}`);
+      const responseJson: Metric = await response.json();
+
+      return responseJson;
+    } catch(error) {
+      Logger.error(`Error while reading the metric: ${error}`);
+
+      return null;
+    }
+  };
+
+}
+
+export default MetricService;


### PR DESCRIPTION
This adds a new page `Metrics` containing assorted metrics made available from the `/actuator` endpoint.

![image](https://user-images.githubusercontent.com/1137620/110955479-f1f2bb00-8349-11eb-9aaa-f1add05b7273.png)

Please review @terrestris/devs.