### PR TITLE
config: use dotenv only in dev mode

### DIFF
--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -1,11 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const webpack = require('webpack');
 const SimpleProgressWebpackPlugin = require('simple-progress-webpack-plugin');
 const CustomAntThemeModifyVars = require('./theme.js');
-const dotenv = require('dotenv').config({
-  path: path.join(__dirname, '.env')
-});
 
 module.exports = {
   entry: [
@@ -92,9 +88,6 @@ module.exports = {
     }),
     new SimpleProgressWebpackPlugin({
       format: 'compact'
-    }),
-    new webpack.DefinePlugin( {
-      'process.env': dotenv.parsed
     })
   ]
 };

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -2,6 +2,11 @@ const commonConfig = require('./webpack.common.config.js');
 const webpack = require('webpack');
 const fetch = require('node-fetch');
 const https = require('https');
+const path = require('path');
+const dotenv = require('dotenv').config({
+  path: path.join(__dirname, '.env'),
+  debug: true
+});
 
 let commonWebpackConfig = commonConfig;
 
@@ -32,6 +37,15 @@ const delayedConf = new Promise(function(resolve) {
     cookiePathRewrite: '/',
     secure: false
   };
+
+  const envVars = dotenv.parsed;
+  const {
+    KEYCLOAK_IP,
+    KEYCLOAK_ADMIN_USER,
+    KEYCLOAK_ADMIN_PWD,
+    KEYCLOAK_CLIENT_ID,
+    KEYCLOAK_REALM
+  } = envVars;
 
   commonWebpackConfig.devServer = {
     historyApiFallback: true,


### PR DESCRIPTION
`.env` file is only required in development mode. Herewith, this is only loaded in `webpack.dev.config.js`

Plz review @terrestris/devs 