### PR TITLE
Breaking: Load form configs from backend

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -29,7 +29,7 @@
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
-    <script src="/shogun-boot/client-config.js"></script>
+    <script src="/admin-client-config.js"></script>
     <script>
       if (!window.shogunApplicationConfig) {
         console.warn('No SHOGun application config found. Loading fallback.');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,8 +35,8 @@ const userService = new UserService();
 
 const App: React.FC = () => {
 
-  const [userInfo, setUserInfo] = useRecoilState(userInfoAtom);
-  const [appInfo, setAppInfo] = useRecoilState(appInfoAtom);
+  const [, setUserInfo] = useRecoilState(userInfoAtom);
+  const [, setAppInfo] = useRecoilState(appInfoAtom);
   const [loadingState, setLoadingState] = useState<'failed' | 'loading' | 'done'>();
 
   // Fetch initial data:
@@ -50,8 +50,9 @@ const App: React.FC = () => {
       setSwaggerDocs(swaggerDoc);
       const a = await AppInfoService.getAppInfo();
       setAppInfo(a);
-      const u = await userService.findOne(appInfo.userId);
+      const u = await userService.findOne(a?.userId);
       setUserInfo(u);
+      setLoadingState('done');
     } catch (error) {
       setLoadingState('failed');
       Logger.error(error);
@@ -59,10 +60,8 @@ const App: React.FC = () => {
   }, [setAppInfo, setUserInfo]);
 
   useEffect(() => {
-    if (_isEmpty(userInfo) || _isEmpty(appInfo)) {
-      getInitialData();
-    }
-  }, [getInitialData, userInfo, appInfo]);
+    getInitialData();
+  }, [getInitialData]);
 
   if (loadingState === 'loading') {
     return (

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -42,7 +42,6 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
   formConfig
 }: GeneralEntityRootProps<T>) {
 
-  // application => Model
   const history = useHistory();
   const location = useLocation();
   const match = matchPath<{ entityId: string }>(location.pathname, {
@@ -84,7 +83,7 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
     entityType,
     formConfig,
     updateForm
-  }), []) as GenericEntityController<T>;
+  }), [endpoint, entityType]) as GenericEntityController<T>;
 
   /**
    * Fetch entity with given id

--- a/src/Controller/ControllerUtil.ts
+++ b/src/Controller/ControllerUtil.ts
@@ -39,7 +39,7 @@ export class ControllerUtil {
    * @returns an application controller instance
    */
   static createApplicationController(controllerCfg: ControllerCfg): GenericEntityController<Application> {
-    const appService = new ApplicationService();
+    const appService = new ApplicationService(controllerCfg?.endpoint);
     const appController = new GenericEntityController<Application>({
       service: appService,
       formUpdater: controllerCfg?.updateForm,

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -96,8 +96,8 @@ export const Portal: React.FC<PortalProps> = () => {
       <div className="content">
         <Switch>
           {
-            entitiesToLoad.map(entityConfig => <Route
-              key={entityConfig.endpoint}
+            entitiesToLoad?.map(entityConfig => <Route
+              key={entityConfig.entityType}
               path={`${config.appPrefix}/portal/${entityConfig?.entityType}`}
               render={() => <GeneralEntityRoot
                 {...entityConfig}

--- a/src/Service/ApplicationService/ApplicationService.ts
+++ b/src/Service/ApplicationService/ApplicationService.ts
@@ -1,12 +1,10 @@
 import GenericService from '../GenericService/GenericService';
-
-import config from 'shogunApplicationConfig';
 import Application from '../../Model/Application';
 
 class ApplicationService extends GenericService<Application> {
 
-  constructor() {
-    super(Application, config.path.application);
+  constructor(endPoint: string) {
+    super(Application, endPoint);
   }
 
 }

--- a/webpack.dev.config.js
+++ b/webpack.dev.config.js
@@ -11,17 +11,6 @@ const dotenv = require('dotenv').config({
 let commonWebpackConfig = commonConfig;
 
 const headers = {};
-
-// `process.env` is defined in the webpack's DefinePlugin
-const envVariables = process.env;
-const {
-  KEYCLOAK_IP,
-  KEYCLOAK_ADMIN_USER,
-  KEYCLOAK_ADMIN_PWD,
-  KEYCLOAK_CLIENT_ID,
-  KEYCLOAK_REALM
-} = envVariables;
-
 const delayedConf = new Promise(function(resolve) {
   commonWebpackConfig.plugins = [
     ...commonWebpackConfig.plugins || [],


### PR DESCRIPTION
This PR introduces the automatic load of form configuration from backend (e.g. shogun-boot). A configuration of a model is loaded if a corresponding entry is located in the models section of the configuration js file

```
...
 },
  models: [
    'Application'
  ],
  dashboard: {
...
```

**convention**
The form configuration (the endpoint definition as well) is tried to be loaded from `<<toLowerCase(MODELNAME).json>>` (here `application.json`). The base path for configuration jsons can be configured in `path.configBase`.

Plz review @terrestris/devs 
