### PR TITLE
Breaking: Introduce configurable entity table (initial version)

### DIFF
--- a/assets/formconfigs/application.json
+++ b/assets/formconfigs/application.json
@@ -52,5 +52,38 @@
       "dataField": "layerConfig",
       "labelI18n": "Layer configuration"
     }]
+  },
+  "tableConfig": {
+    "columnDefinition": [{
+      "title": "ID",
+      "dataIndex": "id",
+      "sortConfig": {
+        "isSortable": true,
+        "defaultSortOrder": "descend"
+      }
+    }, {
+      "title": "Name",
+      "dataIndex": "name",
+      "key": "name",
+      "sortConfig": {
+        "isSortable": false
+      },
+      "filterConfig": {
+        "isFilterable": true
+      }
+    }, {
+      "title": "Last modified",
+      "dataIndex": "modified",
+      "key": "modified",
+      "sortConfig": {
+        "isSortable": true
+      },
+      "cellRenderComponentName": "DateCell"
+    },{
+      "title": "Client configuration",
+      "dataIndex": "clientConfig",
+      "key": "clientConfig",
+      "cellRenderComponentName": "JSONCell"
+    }]
   }
 }

--- a/src/Component/FormField/DisplayField/DisplayField.tsx
+++ b/src/Component/FormField/DisplayField/DisplayField.tsx
@@ -5,10 +5,11 @@ import _isNil from 'lodash/isNil';
 import _isFunction from 'lodash/isFunction';
 import _isFinite from 'lodash/isFinite';
 import _get from 'lodash/get';
+import _isEmpty from 'lodash/isEmpty';
 
 export type DisplayFieldProps = {
   dateFormat?: string;
-  format?: 'date' | 'text';
+  format?: 'date' | 'text' | 'json';
   formatFunction?: (val?: any) => string;
   numberOfDigits?: number;
   suffix?: string;
@@ -45,6 +46,10 @@ const DisplayField: React.FC<DisplayFieldProps> = ({
   let displayText = value;
   if (format === 'date' && value) {
     displayText = moment(value).format(dateFormat);
+  }
+
+  if (format === 'json' && !_isEmpty(value)) {
+    displayText = JSON.stringify(value);
   }
 
   if (Array.isArray(displayText)) {

--- a/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { DatePicker, Form, Input, Statistic, Switch } from 'antd';
+import { DatePicker, Form, Input, PageHeader, Statistic, Switch } from 'antd';
 const { TextArea } = Input;
 
 import Logger from 'js-logger';
@@ -40,7 +40,7 @@ export type FormConfig = {
 };
 
 interface OwnProps {
-  id?: number | 'create';
+  entityName: string;
   formConfig: FormConfig;
   formProps?: Partial<FormProps>;
   form: FormInstance;
@@ -51,6 +51,7 @@ const DEFAULT_DATE_FORMAT = 'DD.MM.YYYY';
 export type GeneralEntityFormProps = OwnProps & React.HTMLAttributes<HTMLDivElement>;
 
 export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
+  entityName,
   formProps,
   form,
   formConfig
@@ -233,20 +234,24 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
 
   const initialValues = {};
 
-  return (
-    <Form
-      className="general-entity-form"
-      form={form}
-      initialValues={initialValues}
-      layout="vertical"
-      name={formConfig?.name}
-      {...formProps}
-    >
-      {
-        parseFormConfig()
-      }
-    </Form>
+  const title = `${entityName}`;
 
+  return (
+    <>
+      <PageHeader title={title} />
+      <Form
+        className="general-entity-form"
+        form={form}
+        initialValues={initialValues}
+        layout="vertical"
+        name={formConfig?.name}
+        {...formProps}
+      >
+        {
+          parseFormConfig()
+        }
+      </Form>
+    </>
   );
 };
 

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.less
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.less
@@ -2,13 +2,14 @@
   height: 100%;
   display: grid;
   grid-template-rows: auto 1fr;
-  grid-template-columns: 40% 60%;
+  grid-template-columns: 50% 50%;
   grid-template-areas:
     "header header"
     "left right";
 
   >div {
     flex: 1;
+    overflow: auto;
 
     &.header {
       grid-area: header;

--- a/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
@@ -1,61 +1,159 @@
 import React, { useMemo } from 'react';
-
-import { EntityTable, EntityTableProps } from '../../../Component/Table/EntityTable/EntityTable';
+import { useHistory } from 'react-router-dom';
 import TableUtil from '../../../Util/TableUtil';
+import _isEmpty from 'lodash/isEmpty';
 
 import config from 'shogunApplicationConfig';
 import BaseEntity from '../../../Model/BaseEntity';
 
-import './GeneralEntityTable.less';
 import { GenericEntityController } from '../../../Controller/GenericEntityController';
+import DisplayField from '../../FormField/DisplayField/DisplayField';
+import Table, { ColumnType, TableProps } from 'antd/lib/table';
+import { Tooltip } from 'antd';
+import { SyncOutlined } from '@ant-design/icons';
+import { SortOrder } from 'antd/lib/table/interface';
+import './GeneralEntityTable.less';
 
-interface OwnProps<EntityType extends BaseEntity> {
-  controller: GenericEntityController<EntityType>;
+export type TableConfig<T extends BaseEntity> = {
+  columnDefinition?: GeneralEntityTableColumn<T>[];
+};
+
+type FilterConfig = {
+  isFilterable: boolean;
+};
+
+type SortConfig = {
+  customSorterName?: string;
+  isSortable: boolean;
+  sortOrder?: SortOrder;
+};
+
+type GeneralEntityTableColumnType = {
+  cellRenderComponentName?: string;
+  filterConfig?: FilterConfig; // if available: property is filterable by corresponding property using default config
+  sortConfig?: SortConfig; // if available: property is sortable by corresponding property using default config
+};
+
+export type GeneralEntityTableColumn<T extends BaseEntity> = ColumnType<T> & GeneralEntityTableColumnType;
+
+type OwnProps<T extends BaseEntity> = {
+  controller: GenericEntityController<T>;
+  entities: T[];
   entityType: string;
-  // TODO: table config
-}
+  fetchEntities?: () => void;
+  onRowClick?: (record: T, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
+  tableConfig: TableConfig<T>;
+};
 
-type GeneralEntityTableProps<EntityType extends BaseEntity> = OwnProps<EntityType> &
-  Omit<EntityTableProps, 'service' | 'routePath' | 'name' | 'columns' > & React.HTMLAttributes<HTMLDivElement>;
+type GeneralEntityTableProps<T extends BaseEntity> = OwnProps<T> & TableProps<T> & React.HTMLAttributes<HTMLDivElement>;
 
-const columns: any = [
-  {
-    title: 'ID',
-    key: 'id',
-    dataIndex: 'id',
-    sorter: TableUtil.getSorter('id'),
-    defaultSortOrder: 'ascend',
-    editable: true
-  },
-  {
-    title: 'Name',
-    key: 'name',
-    dataIndex: 'name',
-    sorter: TableUtil.getSorter('name'),
-    defaultSortOrder: 'ascend',
-    editable: true,
-    ...TableUtil.getColumnSearchProps('name')
-  }
-];
-
-export function GeneralEntityTable<EntityType extends BaseEntity> ({
+export function GeneralEntityTable<T extends BaseEntity> ({
+  entities,
   entityType,
-  controller
-}: GeneralEntityTableProps<EntityType>) {
+  fetchEntities = () => undefined,
+  tableConfig,
+  ...tablePassThroughProps
+}: GeneralEntityTableProps<T>) {
 
-  const service = useMemo(() => controller.getService(), [controller]);
+  const routePath = useMemo(() => `${config.appPrefix}/portal/${entityType}`, [entityType]);
+  const hist = useHistory();
+
+  const onRowClick = (record: T) => hist.push(`${routePath}/${record.id}`);
+
+  const getRenderer = (cellRendererName: string) => (text) => {
+    if (cellRendererName === 'JSONCell') {
+      return <DisplayField value={text} format="json"/>;
+    }
+
+    if (cellRendererName === 'DateCell') {
+      return <DisplayField value={text} format="date"/>;
+    }
+
+    return <>{text}</>;
+  };
+
+  const tableColumns: ColumnType<T>[] = useMemo(() => {
+    let cols = tableConfig?.columnDefinition;
+    if (_isEmpty(cols)) {
+      cols = [{
+        title: 'ID',
+        key: 'id',
+        dataIndex: 'id',
+        sorter: TableUtil.getSorter('id'),
+        defaultSortOrder: 'ascend'
+      }, {
+        title: 'Name',
+        dataIndex: 'name',
+        key: 'name',
+        sorter: TableUtil.getSorter('name'),
+        defaultSortOrder: 'ascend',
+        ...TableUtil.getColumnSearchProps('name')
+      }];
+    } else {
+      // check for preconfigured sorters, filters and custom components (TODO)
+      cols = tableConfig?.columnDefinition.map(cfg => {
+
+        const {
+          sortConfig,
+          filterConfig,
+          cellRenderComponentName
+        } = cfg;
+
+        let columnDef: ColumnType<T> = cfg as ColumnType<T>;
+        if (!_isEmpty(sortConfig) && sortConfig.isSortable) {
+          columnDef = {
+            ...columnDef,
+            sorter: TableUtil.getSorter(cfg.dataIndex.toString()),
+            defaultSortOrder: sortConfig.sortOrder || 'ascend'
+          };
+        }
+        if (!_isEmpty(filterConfig) && filterConfig.isFilterable) {
+          columnDef = {
+            ...columnDef,
+            ...TableUtil.getColumnSearchProps(cfg.dataIndex.toString())
+          };
+        }
+        if (!_isEmpty(cellRenderComponentName)) {
+          columnDef = {
+            ...columnDef,
+            render: getRenderer(cellRenderComponentName)
+          };
+        }
+
+        return columnDef;
+      });
+    }
+
+    return [
+      ...cols,
+      {
+        title: (
+          <Tooltip title="Neu laden">
+            <SyncOutlined
+              onClick={fetchEntities}
+            />
+          </Tooltip>
+        ),
+        className: 'operation-column',
+        width: 100,
+        dataIndex: 'operation',
+        key: 'operation'
+      }
+    ];
+  }, [fetchEntities, tableConfig?.columnDefinition]);
 
   return (
-    <EntityTable
+    <Table
       className="general-entity-table"
-      service={service}
-      routePath={`${config.appPrefix}/portal/${entityType}`}
-      name={{
-        singular: 'Entität',
-        plural: 'Entitäten'
+      columns={tableColumns}
+      dataSource={entities}
+      onRow={(record) => {
+        return {
+          onClick: () => onRowClick(record)
+        };
       }}
-      columns={columns}
-      actions={['delete']}
+      pagination={false}
+      {...tablePassThroughProps}
     />
   );
 };

--- a/src/Component/Table/EntityTable/EntityTable.tsx
+++ b/src/Component/Table/EntityTable/EntityTable.tsx
@@ -255,4 +255,4 @@ export const EntityTable: React.FC<EntityTableProps> = ({
   );
 };
 
-export default EntityTableColumn;
+export default EntityTable;

--- a/src/Controller/GenericEntityController.ts
+++ b/src/Controller/GenericEntityController.ts
@@ -34,7 +34,7 @@ export type GenericEntityControllerArgs<T extends BaseEntity> = {
 export class GenericEntityController<T extends BaseEntity> {
   protected entity: T;
   protected initialValues: FormValues;
-  protected service:  GenericService<T>;
+  protected service: GenericService<T>;
   private formConfig: FormConfig;
   private formUpdater?: (values: FormValues) => void; // maybe not required
   private nextUpdate: FormValues;
@@ -88,9 +88,11 @@ export class GenericEntityController<T extends BaseEntity> {
     await this.service.delete(entity?.id);
   }
 
-  // TODO: This can be removed in the future
-  public getService(): GenericService<T> {
-    return this.service;
+  /**
+   * Fetch all entities
+   */
+  public async findAll(): Promise<T[]> {
+    return await this.service?.findAll();
   }
 
   /**
@@ -158,6 +160,24 @@ export class GenericEntityController<T extends BaseEntity> {
     return {
       validateStatus: 'success'
     };
+  }
+
+  /**
+   * Update passed entity
+   * @param e The entity of type T
+   * @returns The updated entity
+   */
+  public async update(e: T): Promise<T> {
+    return await this.service?.update(e);
+  }
+
+  /**
+   * Save passed entity
+   * @param e The entity of type T
+   * @returns The saved entity
+   */
+  public async add(e: T): Promise<T> {
+    return await this.service?.add(e);
   }
 
   /**

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -23,6 +23,7 @@ import GlobalSettingsRoot from '../../Component/GlobalSettings/GlobalSettingsRoo
 import LogSettingsRoot from '../../Component/LogSettings/LogSettingsRoot/LogSettingsRoot';
 import MetricsRoot from '../../Component/Metrics/MetricsRoot/MetricsRoot';
 import { keycloak } from '../../Util/KeyCloakUtil';
+import BaseEntity from '../../Model/BaseEntity';
 
 import config from 'shogunApplicationConfig';
 
@@ -39,10 +40,10 @@ export const Portal: React.FC<PortalProps> = () => {
 
   const [collapsed, setCollapsed] = useState<boolean>(false);
   const toggleCollapsed = () => setCollapsed(!collapsed);
-  const [entitiesToLoad, setEntitiesToLoad] = useState<GeneralEntityConfigType[]>([]);
+  const [entitiesToLoad, setEntitiesToLoad] = useState<GeneralEntityConfigType<BaseEntity>[]>([]);
   const [configsAreLoading, setConfigsAreLoading] = useState<boolean>(false);
 
-  const fetchConfigForModel = async (modelName: string): Promise<GeneralEntityConfigType> => {
+  const fetchConfigForModel = async (modelName: string): Promise<GeneralEntityConfigType<BaseEntity>> => {
     if (!keycloak.token) {
       Logger.warn('No keycloak token available.');
       return null;
@@ -55,13 +56,16 @@ export const Portal: React.FC<PortalProps> = () => {
         'Authorization': `Bearer ${keycloak.token}`
       }
     };
-    const response = await fetch(`${config.appPrefix}${config.path.configBase}/${_toLowerCase(modelName)}.json`, reqOpts);
+    const response = await fetch(
+      `${config.appPrefix}${config.path.configBase}/${_toLowerCase(modelName)}.json`,
+      reqOpts
+    );
     if (response.ok) {
       if (response.status === 204) {
       // No Data
         return null;
       }
-      return await response.json() as GeneralEntityConfigType;
+      return await response.json() as GeneralEntityConfigType<BaseEntity>;
     } else {
       message.error(`Could not load config for model: ${modelName}`);
       throw new Error(response.statusText);
@@ -70,8 +74,9 @@ export const Portal: React.FC<PortalProps> = () => {
 
   const fetchConfigsForModels = async () => {
     setConfigsAreLoading(true);
-    const formConfigsPromises: Promise<GeneralEntityConfigType>[] = await config?.models?.map(fetchConfigForModel);
-    const formConfigs: GeneralEntityConfigType[] = await Promise.all(formConfigsPromises);
+    const formConfigsPromises: Promise<GeneralEntityConfigType<BaseEntity>>[] =
+      await config?.models?.map(fetchConfigForModel);
+    const formConfigs: GeneralEntityConfigType<BaseEntity>[] =await Promise.all(formConfigsPromises);
     if (!_isEqual(formConfigs, entitiesToLoad)) {
       setEntitiesToLoad(formConfigs);
     }

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -76,7 +76,7 @@ export const Portal: React.FC<PortalProps> = () => {
     setConfigsAreLoading(true);
     const formConfigsPromises: Promise<GeneralEntityConfigType<BaseEntity>>[] =
       await config?.models?.map(fetchConfigForModel);
-    const formConfigs: GeneralEntityConfigType<BaseEntity>[] =await Promise.all(formConfigsPromises);
+    const formConfigs: GeneralEntityConfigType<BaseEntity>[] = await Promise.all(formConfigsPromises);
     if (!_isEqual(formConfigs, entitiesToLoad)) {
       setEntitiesToLoad(formConfigs);
     }

--- a/src/Util/TableUtil.tsx
+++ b/src/Util/TableUtil.tsx
@@ -12,7 +12,7 @@ export default class TableUtil {
     dataIndex: string | string[],
     handleSearch = TableUtil.handleSearch,
     handleReset =  TableUtil.handleReset
-) => {
+  ) => {
     let searchInput;
 
     return {


### PR DESCRIPTION
This PR introduces an initial version of a generic, configurable (via model JSON files introduced in #51) entity table.
The configuration can be made using (optional) `tableConfig` property in model json

```
"tableConfig": {
  "columnDefinition": [{
    "title": "ID",
    "dataIndex": "id",
    "sortConfig": {
      "isSortable": true,
      "defaultSortOrder": "descend"
    }
    }, {
      "title": "Name",
      "dataIndex": "name",
      "key": "name",
      "sortConfig": {
        "isSortable": false
      },
      "filterConfig": {
        "isFilterable": true
      }
    }, {
      "title": "Last modified",
      "dataIndex": "modified",
      "key": "modified",
      "sortConfig": {
        "isSortable": true
      },
      "cellRenderComponentName": "DateCell"
    },{
      "title": "Client configuration",
      "dataIndex": "clientConfig",
      "key": "clientConfig",
      "cellRenderComponentName": "JSONCell"
    }
  ]
}
```

For each `columnDefinition` can be configured:
* `title`: Title in grid
* `dataIndex`: Field name read from entitiy
* `key`: The key
* `sortConfig`: Whether the field should be sortable and in which way
* `filterConfig`: Whether the field should be filterable
* `cellRenderComponentName`: A custom cell renderer (e.g. for JSON values)


If no configuration such is given, `id` and `name` are loaded in table.

Beside, the following changes are included:
* On save of an entity, the grid is reloaded
* Page header for form
* `overflow`

![image](https://user-images.githubusercontent.com/10559603/136373761-2332745b-490d-405e-b93a-5fbc01ae3987.png)

https://github.com/terrestris/shogun-admin/pull/51 should be merged first.

Plz review @terrestris/devs 
