### PR TITLE
Introduces configurable JWT authentication

### DIFF
--- a/assets/fallbackConfig.js
+++ b/assets/fallbackConfig.js
@@ -19,6 +19,10 @@ var shogunApplicationConfig = {
     metrics: '/actuator/metrics',
     evictCache: '/cache/evict'
   },
+  security: {
+    jwt: false,
+    // authTokenKey: 'shogun-auth-token'
+  },
   models: [
     'Application'
   ],

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "The admin UI for the SHOGun Webmapping backend.",
   "main": "index.js",
   "scripts": {
-    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "typecheck": "tsc --project tsconfig.json --noEmit --skipLibCheck",
     "test": "jest",
     "test:watch": "jest --watch",
-    "eslint": "eslint -c .eslintrc.js --ext .js,.ts,.tsx && tsc --noEmit --project tsconfig.json",
+    "eslint": "eslint -c .eslintrc.js --ext .js,.ts,.tsx",
     "lint": "npm run typecheck && npm run eslint ",
     "build": "webpack --config webpack.production.config.js",
     "start": "rimraf dist_dev && webpack serve --config webpack.dev.config.js",

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -27,8 +27,8 @@ import config from 'shogunApplicationConfig';
 
 import GeneralEntityRoot,
 { GeneralEntityConfigType } from '../../Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot';
-import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
 import './Portal.less';
+import SecurityUtil from '../../Util/SecurityUtil';
 
 interface OwnProps { }
 
@@ -46,7 +46,7 @@ export const Portal: React.FC<PortalProps> = () => {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
-        'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie()
+        ...SecurityUtil.getSecurityHeaders(config)
       }
     };
     const modelPath = `${config.path.modelConfigs}/${(modelName.toLowerCase())}.json`;

--- a/src/Service/CacheService/CacheService.ts
+++ b/src/Service/CacheService/CacheService.ts
@@ -1,8 +1,7 @@
-import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
-
 import Logger from '../../Logger';
 
 import config from 'shogunApplicationConfig';
+import SecurityUtil from '../../Util/SecurityUtil';
 
 class CacheService {
 
@@ -12,9 +11,7 @@ class CacheService {
     try {
       const response = await fetch(`${config.path.evictCache}`, {
         method: 'POST',
-        headers: {
-          'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie()
-        }
+        headers: SecurityUtil.getSecurityHeaders(config)
       });
       return response.status === 200;
     } catch (error) {

--- a/src/Service/GenericService/GenericService.ts
+++ b/src/Service/GenericService/GenericService.ts
@@ -1,6 +1,7 @@
-import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
-
 import BaseEntity from '../../Model/BaseEntity';
+import SecurityUtil from '../../Util/SecurityUtil';
+
+import config from 'shogunApplicationConfig';
 
 export type ReplacerFunction = (key: string, value: any) => any;
 
@@ -107,7 +108,7 @@ abstract class GenericService<T extends BaseEntity> {
   getDefaultHeaders() {
     return {
       'Content-Type': 'application/json',
-      'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie()
+      ...SecurityUtil.getSecurityHeaders(config)
     };
   }
 }

--- a/src/Service/GraphQLService/GraphQLService.ts
+++ b/src/Service/GraphQLService/GraphQLService.ts
@@ -1,5 +1,5 @@
 import config from 'shogunApplicationConfig';
-import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
+import SecurityUtil from '../../Util/SecurityUtil';
 
 // TODO: Make this generic and more specific
 export type GraphQLQueryObject = {
@@ -23,7 +23,7 @@ class GraphQLService {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie()
+        ...SecurityUtil.getSecurityHeaders(config)
       },
       body: JSON.stringify(query)
     };

--- a/src/Service/LogService/LogService.ts
+++ b/src/Service/LogService/LogService.ts
@@ -1,15 +1,14 @@
-import CsrfUtil from '@terrestris/base-util/dist/CsrfUtil/CsrfUtil';
-
 import Logger from '../../Logger';
 
 import config from 'shogunApplicationConfig';
+import SecurityUtil from '../../Util/SecurityUtil';
 
 export type LogLevel = 'OFF' | 'FATAL' | 'ERROR' | 'WARN' | 'INFO' | 'DEBUG' | 'TRACE';
 
-export type Logger = {
-  configuredLevel: LogLevel
-  effectiveLevel: LogLevel
-}
+export type LogLevels = {
+  configuredLevel: LogLevel;
+  effectiveLevel: LogLevel;
+};
 
 class LogService {
 
@@ -28,7 +27,7 @@ class LogService {
     }
   }
 
-  async getLogger(loggerName: string): Promise<Logger> {
+  async getLogger(loggerName: string): Promise<LogLevels> {
     try {
       const loggerResponse = await fetch(`${config.path.loggers}/${loggerName}`);
       const loggerJson = await loggerResponse.json();
@@ -47,7 +46,7 @@ class LogService {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie()
+          ...SecurityUtil.getSecurityHeaders(config)
         },
         body: JSON.stringify({
           'configuredLevel': logLevel

--- a/src/Util/SecurityUtil.ts
+++ b/src/Util/SecurityUtil.ts
@@ -1,0 +1,14 @@
+import { CsrfUtil } from '@terrestris/base-util';
+
+export default class SecurityUtil {
+
+  public static getSecurityHeaders(config: any): any {
+    const securityHeaders: any = {
+      'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie(),
+    };
+    if (config?.security?.jwt === true) {
+      securityHeaders.AUTHORIZATION = localStorage.getItem(config?.security?.authTokenKey);
+    }
+    return securityHeaders;
+  }
+}

--- a/src/Util/SecurityUtil.ts
+++ b/src/Util/SecurityUtil.ts
@@ -4,7 +4,7 @@ export default class SecurityUtil {
 
   public static getSecurityHeaders(config: any): any {
     const securityHeaders: any = {
-      'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie(),
+      'X-XSRF-TOKEN': CsrfUtil.getCsrfValueFromCookie()
     };
     if (config?.security?.jwt === true) {
       securityHeaders.AUTHORIZATION = localStorage.getItem(config?.security?.authTokenKey);


### PR DESCRIPTION
This adds a configuration object to configure the security authentication via json web token:

```js
  security: {
    jwt: true,
    authTokenKey: 'shogun-auth-token'
  }
```

The newly introduced `SecurityUtil` will take care of setting the needed headers:
1. The CSRF Token as before: Header `X-XSRF-TOKEN`
2. The JWT if configured in the admin-client-config as shown in the snippet: Header `AUTHORIZATION`
    The AUTHORIZATION header will be collected via localStorage.getItem(config?.security?.authTokenKey)

As this is configurable this should not affect any running system.

