### PR TITLE
Remove KeycloakRepresentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ So to work on the `shogun-admin` you can mount this folder into your docker-comp
     volumes:
       - ../../shogun-admin/dist_dev:/var/www/html
 ```
+
+# Semantic release
+Allowed Tags for semantic release:
+
+- Breaking changes: `breaking`
+- Features: `feat`
+- Bugfixes: `fix`,
+- Package updates: `chore`
+- Changes in configuration: `ci`, `config`
+- `docs`, `refactor`, `test`, `norelease`

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -96,7 +96,7 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
     try {
       const e: T = await entityController?.load(eId) as T;
       setEditEntity(e);
-      form.resetFields();
+      form.setFieldsValue(e);
     } catch (error) {
       Logger.error(error);
     }
@@ -192,7 +192,6 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
               type="primary"
               key="create"
               icon={<FormOutlined />}
-              onClick={onSaveClick}
             >
               {`${entityName} anlegen`}
             </Button>

--- a/src/Component/Menu/User/User.tsx
+++ b/src/Component/Menu/User/User.tsx
@@ -78,10 +78,10 @@ export const User: React.FC<UserProps> = (props) => {
             className="user-name"
           >
             <span>
-              {userInfo?.keycloakRepresentation?.email}
+              {userInfo?.providerDetails?.email}
             </span>
           </div>
-          <Menu.Divider/>
+          <Menu.Divider />
           <Menu.Item
             key="settings"
             icon={<SettingOutlined />}
@@ -94,7 +94,7 @@ export const User: React.FC<UserProps> = (props) => {
           >
             Info
           </Menu.Item>
-          <Menu.Divider/>
+          <Menu.Divider />
           <Menu.Item
             key="logout"
             icon={<LogoutOutlined />}
@@ -118,7 +118,7 @@ export const User: React.FC<UserProps> = (props) => {
         <span
           className="username"
         >
-          {userInfo?.keycloakRepresentation?.username}
+          {userInfo?.providerDetails?.username}
         </span>
       </div>
     </Dropdown>

--- a/src/Component/Menu/User/User.tsx
+++ b/src/Component/Menu/User/User.tsx
@@ -78,7 +78,7 @@ export const User: React.FC<UserProps> = (props) => {
             className="user-name"
           >
             <span>
-              {userInfo?.providerDetails?.email}
+              {userInfo?.authProviderId}
             </span>
           </div>
           <Menu.Divider />
@@ -118,7 +118,7 @@ export const User: React.FC<UserProps> = (props) => {
         <span
           className="username"
         >
-          {userInfo?.providerDetails?.username}
+          {userInfo?.authProviderId}
         </span>
       </div>
     </Dropdown>

--- a/src/Component/Modal/UserProfile/UserProfileForm/UserProfileForm.tsx
+++ b/src/Component/Modal/UserProfile/UserProfileForm/UserProfileForm.tsx
@@ -55,13 +55,13 @@ export const UserProfileForm: React.FC<UserProfileFormProps> = props => {
 
   useEffect(() => {
     form.setFieldsValue({
-      email: userInfo?.keycloakRepresentation?.email,
-      username: userInfo?.keycloakRepresentation?.username,
+      email: userInfo?.providerDetails?.email,
+      username: userInfo?.providerDetails?.username,
       affiliation: userInfo?.details?.affiliation,
       phone: userInfo?.details?.phone,
       about: userInfo?.details?.about
     });
-  }, [userInfo]);
+  }, [userInfo, form]);
 
   const handleSubmit = (values) => {
     setAlert({});
@@ -69,9 +69,9 @@ export const UserProfileForm: React.FC<UserProfileFormProps> = props => {
 
     const updateUser = new User({
       id: userInfo.id,
-      keycloakRepresentation: {
+      providerDetails: {
         username: values.username,
-        email: userInfo?.keycloakRepresentation?.email,
+        email: userInfo?.providerDetails?.email,
         enabled: true
       },
       details: {

--- a/src/Component/Modal/UserProfile/UserProfileForm/UserProfileForm.tsx
+++ b/src/Component/Modal/UserProfile/UserProfileForm/UserProfileForm.tsx
@@ -18,7 +18,6 @@ import {
 
 import {
   ContactsOutlined,
-  MailOutlined,
   PhoneOutlined,
   QuestionCircleOutlined,
   UserOutlined
@@ -55,8 +54,6 @@ export const UserProfileForm: React.FC<UserProfileFormProps> = props => {
 
   useEffect(() => {
     form.setFieldsValue({
-      email: userInfo?.providerDetails?.email,
-      username: userInfo?.providerDetails?.username,
       affiliation: userInfo?.details?.affiliation,
       phone: userInfo?.details?.phone,
       about: userInfo?.details?.about
@@ -69,11 +66,6 @@ export const UserProfileForm: React.FC<UserProfileFormProps> = props => {
 
     const updateUser = new User({
       id: userInfo.id,
-      providerDetails: {
-        username: values.username,
-        email: userInfo?.providerDetails?.email,
-        enabled: true
-      },
       details: {
         phone: values?.phone,
         about: values?.about,
@@ -227,22 +219,6 @@ export const UserProfileForm: React.FC<UserProfileFormProps> = props => {
             })
           }
         </Select>
-      </Form.Item>
-      <Form.Item
-        name="email"
-        label="E-Mail"
-      >
-        <Input
-          prefix={
-            <MailOutlined
-              style={{
-                color: 'rgba(0,0,0,.25)'
-              }}
-            />
-          }
-          disabled={true}
-          placeholder="Email"
-        />
       </Form.Item>
       <Button
         type="primary"

--- a/src/Component/User/UserTable/UserTable.tsx
+++ b/src/Component/User/UserTable/UserTable.tsx
@@ -15,28 +15,28 @@ const columns: any = [
   {
     title: 'Username',
     key: 'username',
-    dataIndex: ['keycloakRepresentation', 'username'],
+    dataIndex: ['providerDetails', 'username'],
     sorter: TableUtil.getSorter('username'),
     defaultSortOrder: 'ascend',
     editable: true,
-    ...TableUtil.getColumnSearchProps(['keycloakRepresentation', 'username'])
+    ...TableUtil.getColumnSearchProps(['providerDetails', 'username'])
   },
   {
     title: 'Vorname',
     key: 'firstname',
-    dataIndex: ['keycloakRepresentation', 'firstName'],
+    dataIndex: ['providerDetails', 'firstName'],
     sorter: TableUtil.getSorter('firstname'),
     defaultSortOrder: 'ascend',
     editable: true,
-    ...TableUtil.getColumnSearchProps(['keycloakRepresentation', 'firstName'])
+    ...TableUtil.getColumnSearchProps(['providerDetails', 'firstName'])
   },
   {
     title: 'Nachname',
-    dataIndex: ['keycloakRepresentation', 'lastName'],
+    dataIndex: ['providerDetails', 'lastName'],
     sorter: TableUtil.getSorter('lastname'),
     defaultSortOrder: 'ascend',
     editable: true,
-    ...TableUtil.getColumnSearchProps(['keycloakRepresentation', 'lastName'])
+    ...TableUtil.getColumnSearchProps(['providerDetails', 'lastName'])
   }
 ];
 

--- a/src/Component/User/UserTable/UserTable.tsx
+++ b/src/Component/User/UserTable/UserTable.tsx
@@ -13,30 +13,13 @@ const userService = new UserService();
 
 const columns: any = [
   {
-    title: 'Username',
-    key: 'username',
-    dataIndex: ['providerDetails', 'username'],
-    sorter: TableUtil.getSorter('username'),
+    title: 'Provider Id',
+    key: 'authProviderId',
+    dataIndex: 'authProviderId',
+    sorter: TableUtil.getSorter('authProviderId'),
     defaultSortOrder: 'ascend',
-    editable: true,
-    ...TableUtil.getColumnSearchProps(['providerDetails', 'username'])
-  },
-  {
-    title: 'Vorname',
-    key: 'firstname',
-    dataIndex: ['providerDetails', 'firstName'],
-    sorter: TableUtil.getSorter('firstname'),
-    defaultSortOrder: 'ascend',
-    editable: true,
-    ...TableUtil.getColumnSearchProps(['providerDetails', 'firstName'])
-  },
-  {
-    title: 'Nachname',
-    dataIndex: ['providerDetails', 'lastName'],
-    sorter: TableUtil.getSorter('lastname'),
-    defaultSortOrder: 'ascend',
-    editable: true,
-    ...TableUtil.getColumnSearchProps(['providerDetails', 'lastName'])
+    editable: false,
+    ...TableUtil.getColumnSearchProps('authProviderId')
   }
 ];
 

--- a/src/Controller/GenericEntityController.ts
+++ b/src/Controller/GenericEntityController.ts
@@ -121,10 +121,10 @@ export class GenericEntityController<T extends BaseEntity> {
    * @returns The updated / saved entitiy
    */
   public async saveOrUpdate(): Promise<T> {
-    const isUpdate = _isNumber(this.entity.id);
+    const isUpdate = _isNumber(this?.entity?.id);
 
     // omit constant fields and read only fields
-    let entityUpdateObject: Partial<T> = _omit(this.entity, [
+    let entityUpdateObject: Partial<T> = _omit(this?.entity, [
       'created',
       'modified',
       ...this.formConfig?.fields.filter(field => field.readOnly).map(field => field.dataField)
@@ -134,7 +134,7 @@ export class GenericEntityController<T extends BaseEntity> {
     if (isUpdate) {
       entityUpdateObject = {
         ...entityUpdateObject,
-        id: this.entity.id
+        id: this?.entity?.id
       };
     }
 

--- a/src/Model/User.ts
+++ b/src/Model/User.ts
@@ -1,17 +1,19 @@
 import BaseEntity, { BaseEntityArgs } from './BaseEntity';
 
 export interface UserArgs extends BaseEntityArgs {
+  authProviderId?: string;
   providerDetails?: any;
   clientConfig?: any;
   details?: any;
 }
 
 export default class User extends BaseEntity {
+  authProviderId?: string;
   providerDetails?: any;
   details?: any;
   clientConfig?: any;
 
-  constructor({id, created, modified, details, clientConfig, providerDetails}: UserArgs) {
+  constructor({id, created, modified, authProviderId, details, clientConfig, providerDetails}: UserArgs) {
     super({
       id,
       created,
@@ -21,5 +23,6 @@ export default class User extends BaseEntity {
     this.details = details;
     this.clientConfig = clientConfig;
     this.providerDetails = providerDetails;
+    this.authProviderId = authProviderId;
   }
 }

--- a/src/Model/User.ts
+++ b/src/Model/User.ts
@@ -1,59 +1,25 @@
 import BaseEntity, { BaseEntityArgs } from './BaseEntity';
 
-export interface KeycloakRepresentation {
-  self?: any;
-  id?: string;
-  origin?: any;
-  createdTimestamp?: number;
-  username?: string;
-  enabled?: boolean;
-  totp?: boolean;
-  emailVerified?: boolean;
-  firstName?: string;
-  lastName?: string;
-  email?: string;
-  federationLink?: string;
-  serviceAccountClientId?: string;
-  attributes?: any;
-  credentials?: any;
-  disableableCredentialTypes?: any[];
-  requiredActions?: any[];
-  federatedIdentities?: any;
-  realmRoles?: any;
-  clientRoles?: any;
-  clientConsents?: any;
-  notBefore?: number;
-  applicationRoles?: any;
-  socialLinks?: any;
-  groups?: any;
-  access?: {
-    manageGroupMembership?: boolean;
-    view?: boolean;
-    mapRoles?: boolean;
-    impersonate?: boolean;
-    manage?: boolean;
-  };
-}
-
 export interface UserArgs extends BaseEntityArgs {
-  keycloakId?: string;
-  keycloakRepresentation?: KeycloakRepresentation;
+  providerDetails?: any;
   clientConfig?: any;
   details?: any;
 }
 
 export default class User extends BaseEntity {
-  keycloakId?: string;
-  keycloakRepresentation?: KeycloakRepresentation;
+  providerDetails?: any;
   details?: any;
   clientConfig?: any;
 
-  constructor({id, created, modified, details, clientConfig, keycloakId, keycloakRepresentation}: UserArgs) {
-    super({id, created, modified});
+  constructor({id, created, modified, details, clientConfig, providerDetails}: UserArgs) {
+    super({
+      id,
+      created,
+      modified
+    });
 
     this.details = details;
     this.clientConfig = clientConfig;
-    this.keycloakId = keycloakId;
-    this.keycloakRepresentation = keycloakRepresentation;
+    this.providerDetails = providerDetails;
   }
 }

--- a/src/State/atoms.ts
+++ b/src/State/atoms.ts
@@ -17,7 +17,7 @@ export const appInfoAtom = atom<AppInfo>({
 export const userInfoAtom = atom<User>({
   key: 'userInfo',
   default: {
-    keycloakRepresentation: {
+    providerDetails: {
       username: 'Peter Pan',
       email: 'pan@terrestris.de'
     }

--- a/src/State/atoms.ts
+++ b/src/State/atoms.ts
@@ -17,10 +17,7 @@ export const appInfoAtom = atom<AppInfo>({
 export const userInfoAtom = atom<User>({
   key: 'userInfo',
   default: {
-    providerDetails: {
-      username: 'Peter Pan',
-      email: 'pan@terrestris.de'
-    }
+    authProviderId: 'peter@pan.de'
   }
 });
 

--- a/src/Util/TableUtil.tsx
+++ b/src/Util/TableUtil.tsx
@@ -24,14 +24,21 @@ export default class TableUtil {
             value={selectedKeys[0]}
             onChange={e => setSelectedKeys(e.target.value ? [e.target.value] : [])}
             onPressEnter={() => handleSearch(selectedKeys, confirm, dataIndex)}
-            style={{ width: 188, marginBottom: 8, display: 'block' }}
+            style={{
+              width: 188,
+              marginBottom: 8,
+              display: 'block'
+            }}
           />
           <Button
             type="primary"
             onClick={() => handleSearch(selectedKeys, confirm, dataIndex)}
             icon={<SearchOutlined />}
             size="small"
-            style={{ width: 90, marginRight: 8 }}
+            style={{
+              width: 90,
+              marginRight: 8
+            }}
           >
             Filter
           </Button>

--- a/src/Util/UserUtil.ts
+++ b/src/Util/UserUtil.ts
@@ -13,11 +13,14 @@ export default class UserUtil {
    * @method getInitials
    */
   public static getInitials(user: User): string {
+    if (!user?.providerDetails) {
+      return undefined;
+    }
     const {
       username,
       firstName,
       lastName
-    } = user.keycloakRepresentation;
+    } = user.providerDetails;
 
     let name = username;
     if (firstName && lastName) {

--- a/src/Util/UserUtil.ts
+++ b/src/Util/UserUtil.ts
@@ -13,26 +13,7 @@ export default class UserUtil {
    * @method getInitials
    */
   public static getInitials(user: User): string {
-    if (!user?.providerDetails) {
-      return undefined;
-    }
-    const {
-      username,
-      firstName,
-      lastName
-    } = user.providerDetails;
-
-    let name = username;
-    if (firstName && lastName) {
-      name = `${firstName} ${lastName}`;
-    }
-    const splittedName = name.split(' ');
-    const initals = [];
-    splittedName.forEach((part) => {
-      if (part[0]) {
-        initals.push(part[0].toUpperCase());
-      }
-    });
-    return initals.join('');
+    // TODO: get the intials form a username config
+    return '🔧';
   }
 }


### PR DESCRIPTION
This removes all the keycloak stuff from the shogun-admin. Unfortunatley this includes the user details as these are unkonwn to the admin now.

In the future we should add config on how to get the username and so on from the `providerDetails` to the shogun `admin-client-config.js`.