### PR TITLE
fix: properly set markdown value on edit

### DIFF
--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
@@ -17,6 +17,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   }, [value]);
 
   const onMarkdownChange = (val: string) => {
+    setMarkdown(val);
     onChange(val);
   };
 


### PR DESCRIPTION
Title says it all.

Prevents the undesired behaviour when the cursor will jump to the end of the line on every change. This makes it impossible to edit text that is not at the end of the input.

Please review @terrestris/devs 