### PR TITLE
Introduces data mapping for table columns

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -137,10 +137,11 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
     if (entityId === 'create') {
       setEditEntity(undefined);
       setId(entityId);
+      form.resetFields();
     } else {
       setId(parseInt(entityId, 10));
     }
-  }, [entityId]);
+  }, [entityId, form]);
 
   // Once the controller is known we need to set the formUpdater so we can update
   // a given form when the entity is updated via controller

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -187,15 +187,6 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
         title={navigationTitle}
         subTitle={subTitle}
         extra={[
-          <Link key="create" to={`${config.appPrefix}/portal/${entityType}/create`}>
-            <Button
-              type="primary"
-              key="create"
-              icon={<FormOutlined />}
-            >
-              {`${entityName} anlegen`}
-            </Button>
-          </Link>,
           <Button
             disabled={saveReloadDisabled || !formValid}
             icon={<SaveOutlined />}
@@ -218,6 +209,17 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
       >
       </PageHeader>
       <div className="left-container">
+        <div className="left-toolbar">
+          <Link key="create" to={`${config.appPrefix}/portal/${entityType}/create`}>
+            <Button
+              type="primary"
+              key="create"
+              icon={<FormOutlined />}
+            >
+              {`${entityName} anlegen`}
+            </Button>
+          </Link>
+        </div>
         <GeneralEntityTable
           bordered
           controller={entityController}

--- a/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
@@ -17,6 +17,13 @@ import './GeneralEntityTable.less';
 
 export type TableConfig<T extends BaseEntity> = {
   columnDefinition?: GeneralEntityTableColumn<T>[];
+  dataMapping?: DataMapping;
+};
+
+type DataMapping = {
+  [dataIndex: string]: {
+    [key: string]: string;
+  };
 };
 
 type FilterConfig = {
@@ -114,21 +121,20 @@ export function GeneralEntityTable<T extends BaseEntity>({
     });
   };
 
-  const getRenderer = (cellRendererName: string) => (text) => {
+  const getRenderer = (cellRendererName: string, mapping?: {[key: string]: string}) => (value: any) => {
+    const displayValue = mapping ? mapping[value] : value;
     if (cellRendererName === 'JSONCell') {
-      return <DisplayField value={text} format="json" />;
+      return <DisplayField value={displayValue} format="json" />;
     }
-
     if (cellRendererName === 'DateCell') {
-      return <DisplayField value={text} format="date" />;
+      return <DisplayField value={displayValue} format="date" />;
     }
-
-    return <>{text}</>;
+    return <>{displayValue}</>;
   };
 
   const getTableColumns = (): ColumnType<T>[] => {
-    let cols = tableConfig?.columnDefinition;
-    if (_isEmpty(cols)) {
+    let cols: GeneralEntityTableColumn<T>[];
+    if (_isEmpty(tableConfig?.columnDefinition)) {
       cols = [{
         title: 'ID',
         key: 'id',
@@ -167,10 +173,11 @@ export function GeneralEntityTable<T extends BaseEntity>({
             ...TableUtil.getColumnSearchProps(cfg.dataIndex.toString())
           };
         }
-        if (!_isEmpty(cellRenderComponentName)) {
+        const mapping = tableConfig.dataMapping?.[cfg.dataIndex.toString()];
+        if (!_isEmpty(cellRenderComponentName) || !_isEmpty(mapping)) {
           columnDef = {
             ...columnDef,
-            render: getRenderer(cellRenderComponentName)
+            render: getRenderer(cellRenderComponentName, mapping)
           };
         }
 

--- a/src/Component/Menu/Navigation/Navigation.tsx
+++ b/src/Component/Menu/Navigation/Navigation.tsx
@@ -66,7 +66,7 @@ export const Navigation: React.FC<NavigationProps> = ({
                 key={entityConfig.entityType}
               >
                 <BankOutlined />
-                <span>{entityConfig.entityName}</span>
+                <span>{entityConfig.navigationTitle}</span>
               </Menu.Item>
             );
           })


### PR DESCRIPTION
This adds the `dataMapping` to the `tableConfig`.
This way values can be transformed befored displayed in the table.
e.g:
```json
"tableConfig": {
    "dataMapping": {
      "category":  {
        "NEWS": "Neuigkeiten",
        "MISC": "Redaktioneller Beitrag",
        "TERMS": "Nutzungsbedingungen",
        "CONTACT": "Kontakt",
        "PRIVACYPOLICY": "Datenschutz",
        "IMPRINT": "Impressum",
        "LINK_ONLY": "Externer Link"
      }
    },
    …
}
```

This also fixes some bugs:
- Clear entity form when hitting the create new entity button
- Make use of the navigationTitle in the navigation

It also moves the create button from the top right to above the table.