### PR TITLE
Introduce fullscreen wrapper

### DIFF
--- a/src/App.less
+++ b/src/App.less
@@ -1,6 +1,7 @@
 .app {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 
   .suspense-spin {
     margin: auto;

--- a/src/Component/FormField/JSONEditor/JSONEditor.less
+++ b/src/Component/FormField/JSONEditor/JSONEditor.less
@@ -1,7 +1,3 @@
-.json-editor {
-  .monaco-editor {
-    min-height: 15vh !important;
-  }
-  resize: vertical;
-  overflow-y: hidden;
+section .monaco-editor {
+  max-height: 140px !important;
 }

--- a/src/Component/FormField/JSONEditor/JSONEditor.tsx
+++ b/src/Component/FormField/JSONEditor/JSONEditor.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import Editor, { EditorProps, Monaco } from '@monaco-editor/react';
 import Logger from 'js-logger';
+import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
 
 import cloneDeep from 'lodash/cloneDeep';
 
@@ -133,15 +134,16 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
   };
 
   return (
-    <Editor
-      className="json-editor"
-      value={currentValue}
-      onChange={changeHandler}
-      path={entityName ? `${entityName}.json` : undefined}
-      language="json"
-      beforeMount={onEditorMount}
-      {...editorProps}
-    />
+    <FullscreenWrapper>
+      <Editor
+        value={currentValue}
+        onChange={changeHandler}
+        path={entityName ? `${entityName}.json` : undefined}
+        language="json"
+        beforeMount={onEditorMount}
+        {...editorProps}
+      />
+    </FullscreenWrapper>
   );
 };
 

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
@@ -1,0 +1,14 @@
+.w-md-editor {
+    height: 100% !important;
+    display: flex;
+    flex-direction: column;
+
+    .w-md-editor-content {
+        flex: 1;
+    }
+
+    .w-md-editor-toolbar-divider:last-of-type,
+    .w-md-editor-bar {
+        display: none;
+    }
+}

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
@@ -1,9 +1,19 @@
 import React, { useEffect } from 'react';
-import MDEditor from '@uiw/react-md-editor';
+import MDEditor, { ICommand } from '@uiw/react-md-editor';
+
+import './MarkdownEditor.less';
+import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
 
 export type MarkdownEditorProps = {
   value?: string;
   onChange?: (value: string) => void;
+};
+
+export const commandsFilter = (command: ICommand) => {
+  if (command?.name === 'fullscreen') {
+    return false;
+  }
+  return command;
 };
 
 export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
@@ -22,10 +32,13 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   };
 
   return (
-    <MDEditor
-      value={markdown}
-      onChange={onMarkdownChange}
-    />
+    <FullscreenWrapper>
+      <MDEditor
+        value={markdown}
+        commandsFilter={commandsFilter}
+        onChange={onMarkdownChange}
+      />
+    </FullscreenWrapper>
   );
 };
 

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect } from 'react';
 import MDEditor, { ICommand } from '@uiw/react-md-editor';
+import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
 
 import './MarkdownEditor.less';
-import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
 
 export type MarkdownEditorProps = {
   value?: string;

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.less
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.less
@@ -1,0 +1,50 @@
+.fs-wrapper {
+  border: solid 1px #dedede;
+  border-radius: 3px;
+  flex-direction: column;
+  height: 200px;
+  max-height: 200px;
+  display: flex;
+  padding: 10px;
+
+  >div {
+    width: 100%;
+    border-bottom: solid 1px #dedede;
+    margin: 0 5px 5px 0;
+    padding-bottom: 5px;
+
+    >button {
+      float: right;
+    }
+  }
+
+  &:hover {
+    border: solid 1px #40a9ff;
+  }
+
+  &:hover:active,
+  &:focus {
+    box-shadow: 0 0 0 3px rgb(24 144 255 / 20%);
+  }
+
+  &.fullscreen {
+    transition: ease-in .2s;
+    background: white;
+    height: 100vh;
+    max-height: 100vh;
+    z-index: 999;
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100vw;
+    right: 0;
+    bottom: 0;
+    height: 100vh;
+
+    &:hover,
+    &:focus {
+      border: none;
+      box-shadow: none;
+    }
+  }
+}

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.tsx
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.tsx
@@ -19,7 +19,7 @@ export const FullscreenWrapper: React.FC<React.HTMLAttributes<HTMLDivElement>> =
     <div className={wrapperCls}>
       <div>
         <Tooltip
-          title={`Fullscreenmodus ${fullscreen ? ' verlassen' : ''}`}
+          title={`Vollbild ${fullscreen ? ' verlassen' : ''}`}
           placement='left'
         >
           <Button

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.tsx
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { FullscreenExitOutlined, FullscreenOutlined } from '@ant-design/icons';
+import { Button, Tooltip } from 'antd';
+
+import './FullscreenWrapper.less';
+
+export const FullscreenWrapper: React.FC<React.HTMLAttributes<HTMLDivElement>> = ({
+  children
+}) => {
+  const [fullscreen, setFullscreen] = React.useState<boolean>(false);
+
+  const toggleFullscreen = () => {
+    setFullscreen(!fullscreen);
+  };
+
+  const wrapperCls = `fs-wrapper${fullscreen ? ' fullscreen' : ''}`;
+
+  return (
+    <div className={wrapperCls}>
+      <div>
+        <Tooltip
+          title={`Fullscreenmodus ${fullscreen ? ' verlassen' : ''}`}
+          placement='left'
+        >
+          <Button
+            icon={fullscreen ? <FullscreenExitOutlined /> : <FullscreenOutlined />}
+            size='small'
+            onClick={toggleFullscreen}
+          />
+        </Tooltip>
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export default FullscreenWrapper;


### PR DESCRIPTION
Add `FullscreenWrapper` component which expands its underlying children to 100% viewport height and width.

Currently used with `JsonEditor` and `MarkdownEditor` components.

![image](https://user-images.githubusercontent.com/3939355/167837793-3c04cb20-958d-4ebf-97e9-eaddf780275a.png)


Please review @terrestris/devs 