### PR TITLE
Editor styling

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -15,6 +15,7 @@
         "breaking",
         "chore",
         "feat",
+        "style",
         "ci",
         "fix",
         "refactor",

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -12,6 +12,7 @@
           {"type": "config", "release": "patch"},
           {"type": "norelease", "release": false},
           {"type": "refactor", "release": "patch"},
+          {"type": "style", "release": "patch"},
           {"type": "test", "release": false}
         ]
       }
@@ -33,7 +34,7 @@
             {"type": "norelease", "hidden": true },
             {"type": "perf", "hidden": true},
             {"type": "refactor", "hidden": true},
-            {"type": "style", "hidden": true},
+            {"type": "style", "section": "Changes in layout"},
             {"type": "test", "hidden": true}
           ]
         }

--- a/src/Component/FormField/JSONEditor/JSONEditor.less
+++ b/src/Component/FormField/JSONEditor/JSONEditor.less
@@ -1,3 +1,12 @@
-section .monaco-editor {
-  max-height: 140px !important;
+.json-editor {
+  resize: vertical;
+  overflow: auto;
+
+  section {
+    border: 1px solid #dedede;
+
+    .monaco-editor {
+      min-height: 10em;
+    }
+  }
 }

--- a/src/Component/FormField/JSONEditor/JSONEditor.tsx
+++ b/src/Component/FormField/JSONEditor/JSONEditor.tsx
@@ -135,14 +135,19 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
 
   return (
     <FullscreenWrapper>
-      <Editor
-        value={currentValue}
-        onChange={changeHandler}
-        path={entityName ? `${entityName}.json` : undefined}
-        language="json"
-        beforeMount={onEditorMount}
-        {...editorProps}
-      />
+      <div className='json-editor'>
+        <Editor
+          value={currentValue}
+          onChange={changeHandler}
+          path={entityName ? `${entityName}.json` : undefined}
+          language="json"
+          beforeMount={onEditorMount}
+          options={{
+            scrollBeyondLastLine: false
+          }}
+          {...editorProps}
+        />
+      </div>
     </FullscreenWrapper>
   );
 };

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
@@ -1,6 +1,7 @@
 .w-md-editor {
-    height: 100% !important;
     display: flex;
+    resize: vertical;
+    overflow: auto;
     flex-direction: column;
 
     .w-md-editor-content {

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.less
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.less
@@ -2,8 +2,6 @@
   border: solid 1px #dedede;
   border-radius: 3px;
   flex-direction: column;
-  height: 200px;
-  max-height: 200px;
   display: flex;
   padding: 10px;
 


### PR DESCRIPTION
This updates the styling of `JSONEditor` and `MarkdownEditor`.

- adds border to JSONEditor
- set scrollBeyondLastLine to false
- allow resizing of JSONEditor and MarkdownEditor 