### PR TITLE
Fix fullscreen mode

### DIFF
--- a/src/Component/FormField/JSONEditor/JSONEditor.less
+++ b/src/Component/FormField/JSONEditor/JSONEditor.less
@@ -1,6 +1,5 @@
 .json-editor {
-  resize: vertical;
-  overflow: auto;
+  height: 100%;
 
   section {
     border: 1px solid #dedede;

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
@@ -1,8 +1,7 @@
 .w-md-editor {
     display: flex;
-    resize: vertical;
-    overflow: auto;
     flex-direction: column;
+    flex: 1;
 
     .w-md-editor-content {
         flex: 1;

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.less
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.less
@@ -4,6 +4,10 @@
   flex-direction: column;
   display: flex;
   padding: 10px;
+  resize: vertical;
+  overflow: hidden;
+  min-height: 25vh;
+  max-height: 50vh;
 
   >div {
     width: 100%;
@@ -27,9 +31,9 @@
 
   &.fullscreen {
     transition: ease-in .2s;
+    resize: none;
     background: white;
-    height: 100vh;
-    max-height: 100vh;
+    min-height: 100vh;
     z-index: 999;
     position: fixed;
     left: 0;


### PR DESCRIPTION
* Ensure that wrapper takes a 100% height of viewport if fullscreen mode was activated
* Make wrapper resizable

This behaviour was broken with changes introduced via https://github.com/terrestris/shogun-admin/pull/80.

Please review @KaiVolland 