### PR TITLE
Introduce `LinkCell` renderer

### DIFF
--- a/src/Component/FormField/LinkField/LinkField.less
+++ b/src/Component/FormField/LinkField/LinkField.less
@@ -1,0 +1,4 @@
+.link-wrapper {
+  display: flex;
+  justify-content: space-around;
+}

--- a/src/Component/FormField/LinkField/LinkField.tsx
+++ b/src/Component/FormField/LinkField/LinkField.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import {
+  Tooltip,
+  TooltipProps
+} from 'antd';
+
+import { LinkOutlined } from '@ant-design/icons';
+
+import _isNil from 'lodash/isNil';
+import _isFunction from 'lodash/isFunction';
+import _isFinite from 'lodash/isFinite';
+import _get from 'lodash/get';
+import _isEmpty from 'lodash/isEmpty';
+
+import './LinkField.less';
+
+export type LinkFieldProps = {
+  value: string;
+  template?: string;
+} & Partial<TooltipProps>;
+
+export const LinkField: React.FC<LinkFieldProps> = ({
+  value,
+  template = '{}',
+  title = 'Öffne Link',
+  ...passThroughProps
+}): JSX.Element => {
+
+  const onClick = () => {
+    const link = template.replace(/{}/g, value);
+    window.open(link, '_blank');
+  };
+
+  return (
+    <Tooltip
+      title={title}
+      {...passThroughProps}
+    >
+      <div
+        className="link-wrapper"
+      >
+        <LinkOutlined
+          onClick={onClick}
+        />
+      </div>
+    </Tooltip>
+  );
+};
+
+export default LinkField;

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.less
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.less
@@ -18,6 +18,10 @@
     &.left-container {
       grid-area: left;
       padding: 0 10px 0 24px;
+
+      .left-toolbar {
+        padding: 0 0 10px 0;
+      }
     }
 
     &.right-container {

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -39,7 +39,7 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
   entityType,
   entityName = 'Entität',
   navigationTitle = 'Entitäten',
-  subTitle = '… mit denen man Dingen tun kann (aus Gründen bspw.)',
+  subTitle = '… mit denen man Dinge tun kann (aus Gründen bspw.)',
   formConfig,
   tableConfig = {}
 }: GeneralEntityRootProps<T>) {

--- a/src/Component/Menu/User/User.less
+++ b/src/Component/Menu/User/User.less
@@ -3,6 +3,7 @@
   font-size: 1.2em;
   font-weight: bold;
   cursor: pointer;
+  margin-right: 20px;
 
   .ant-avatar {
     border: 1px solid @primary-color;


### PR DESCRIPTION
This introduces the `LinkCell` renderer which applies a link to the entity table if set.

Example configuration:

```json
{
  "title": "Link zur Applikation",
  "dataIndex": "id",
  "key": "link",
  "cellRenderComponentName": "LinkCell",
  "cellRenderComponentProps": {
    "title": "Öffne Applikation",
    "template": "/client?applicationId={}"
  }
}
```

The `template` prop will resolve any occurrences of the placeholder `{}` with the current value of the cell, e.g. the id of an entity.

![image](https://user-images.githubusercontent.com/1137620/168293096-6990f484-3338-45de-8a91-f418a88b8dac.png)

Please review @terrestris/devs.