### PR TITLE
Fixes release via CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,8 +2,6 @@
 .git
 .husky
 coverage
-dist
-nginx
 node_modules
 .dockerignore
 .editorconfig


### PR DESCRIPTION
This removes `nginx` and `dist` from `.gitignore` as they are need for the release.

~~It also moves the "Semantic Release" step to the end of the CI script so the tag is only created when pushing to the NEXUS-Repository finished correctly.~~ <-- This was undone in the rebase (force-push)