### PR TITLE
Get template value from subpath

### DIFF
--- a/src/Component/FormField/LinkField/LinkField.tsx
+++ b/src/Component/FormField/LinkField/LinkField.tsx
@@ -5,24 +5,28 @@ import {
   TooltipProps
 } from 'antd';
 
+import _get from 'lodash/get';
+
 import { LinkOutlined } from '@ant-design/icons';
 
 import './LinkField.less';
 
 export type LinkFieldProps = {
-  value: string;
+  value: any;
+  valuePath?: string;
   template?: string;
 } & Partial<TooltipProps>;
 
 export const LinkField: React.FC<LinkFieldProps> = ({
   value,
+  valuePath,
   template = '{}',
   title = 'Öffne Link',
   ...passThroughProps
 }): JSX.Element => {
 
   const onClick = () => {
-    const link = template.replace(/{}/g, value);
+    const link = template.replace(/{}/g, valuePath ? _get(value, valuePath) : value);
     window.open(link, '_blank');
   };
 


### PR DESCRIPTION
This suggests to introduce the `valuePath` prop for the `LinkCell`. This prop can be used to get the template value from a subpath if the current value is an object. 

Example configuration:

```json
{
  "title": "Layervorschau (GeoServer)",
  "dataIndex": "sourceConfig",
  "key": "preview",
  "cellRenderComponentName": "LinkCell",
  "cellRenderComponentProps": {
    "title": "Öffne Layervorschau",
    "valuePath": "layerNames",
    "template": "/geoserver/wms/reflect?format=application/openlayers&layers={}"
  }
}
```

The syntax for the prop is as described in [here](https://docs-lodash.com/v4/get/).

Please review @terrestris/devs.