### PR TITLE
JSONSchema generation and minor styling change

### DIFF
--- a/src/Component/FormField/JSONEditor/JSONEditor.tsx
+++ b/src/Component/FormField/JSONEditor/JSONEditor.tsx
@@ -68,11 +68,10 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
       if (definition.properties) {
         Object.values(definition.properties).forEach((property: any) => {
           if (property.$ref) {
-            property.$ref = `${id}${property.$ref}`;
+            property.$ref = `${property.$ref}`;
           }
-
           if (property.items?.$ref) {
-            property.items.$ref = `${id}${property.items.$ref}`;
+            property.items.$ref = `${property.items.$ref}`;
           }
         });
       }

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.less
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.less
@@ -7,7 +7,6 @@
   resize: vertical;
   overflow: hidden;
   min-height: 25vh;
-  max-height: 50vh;
 
   >div {
     width: 100%;


### PR DESCRIPTION
This uses relative refs in the generated JSONSchema.
It also removes the `max-height` from the `FullscreenWrapper`.