### PR TITLE
Removes `config.path.base` from Logo in Header

### DIFF
--- a/assets/fallbackConfig.js
+++ b/assets/fallbackConfig.js
@@ -1,7 +1,6 @@
 var shogunApplicationConfig = {
   appPrefix: '',
   path: {
-    base: 'http://localhost:8080',
     swagger: '/v2/api-docs',
     modelConfigs: '/formconfigs',
     user: '/users',

--- a/src/Component/Header/Header.tsx
+++ b/src/Component/Header/Header.tsx
@@ -20,9 +20,7 @@ type HeaderProps = OwnProps;
 
 export const Header: React.FC<HeaderProps> = () => {
 
-  const logo = config.path?.logo ?
-    `${config.path.base}${config.path?.logo}` :
-    defaultLogo;
+  const logo = config.path?.logo|| defaultLogo;
 
   return (
     <header>


### PR DESCRIPTION
This removes the `config.path.base` prefix from the logo path in the Header.

:exclamation: It is a breaking change as existing configs may relied on the `path.base` configuration.

As this was the only usage of the base path in the admin client this can be removed completly from any `admin-client-config.js`.