### PR TITLE
Fixes changeHanlder of JSONEditor

### DIFF
--- a/src/Component/FormField/JSONEditor/JSONEditor.tsx
+++ b/src/Component/FormField/JSONEditor/JSONEditor.tsx
@@ -51,7 +51,7 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
       onChange(jsonObject);
     } catch (error) {
       if (val.length === 0) {
-        onChange(undefined);
+        onChange(null);
       }
       Logger.trace('JSON-Editor:', error);
     }


### PR DESCRIPTION
This fixes the changeHandler of the JSONEditor when clearing the editor completly.
The previous return of `undefined` did not update the entity properly so it was changed to `null`.