### PR TITLE
feat: add feedback when saving entities

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -5,7 +5,7 @@ import {
   matchPath,
   Link
 } from 'react-router-dom';
-import { Button, PageHeader, Form } from 'antd';
+import { Button, PageHeader, Form, notification } from 'antd';
 import _isEmpty from  'lodash/isEmpty';
 
 import { ControllerUtil } from '../../../Controller/ControllerUtil';
@@ -178,9 +178,19 @@ export function GeneralEntityRoot<T extends BaseEntity> ({
   };
 
   const onSaveClick = async () => {
-    const updatedEntity: T = await entityController?.saveOrUpdate() as T;
-    await fetchEntities();
-    history.push(`${config.appPrefix}/portal/${entityType}/${updatedEntity.id}`);
+    try {
+      const updatedEntity: T = await entityController?.saveOrUpdate() as T;
+      await fetchEntities();
+      history.push(`${config.appPrefix}/portal/${entityType}/${updatedEntity.id}`);
+      notification.success({
+        message: `${entityName} erfolgreich gespeichert!`
+      });
+    } catch (error) {
+      Logger.error(`Error saving ${entityName}:`, error);
+      notification.error({
+        message: `Fehler: Konnte ${entityName} nicht speichern.`
+      });
+    }
   };
 
   const initialValues = useMemo(() => entityController?.getInitialFormValues(), [entityController]);


### PR DESCRIPTION
Shows a simple error / success message when saving entities:

![image](https://user-images.githubusercontent.com/5795523/180739752-4989c6de-c55f-4461-8756-abfe0a293f2e.png)

I chose to implement this in `GeneralEntityRoot` instead of the controller because this keeps anything UI related out of the controller. Let me know what you think.

@terrestris/devs Please review