### PR TITLE
fix: add semantic-release github plugin

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -57,6 +57,7 @@
         ],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
-    ]
+    ],
+    "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
Follow-up to #108 

With this plugin semantic-release should create a github release again.

@terrestris/devs Please review