### PR TITLE
ci: scans the jest coverage and sends a report to sonarqube

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -72,6 +72,10 @@ jobs:
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
+      - name: Install dependencies
+        run: yarn
+      - name: Test and coverage
+        run: yarn jest --coverage
       - name: SonarQube Scan
         uses: kitabisa/sonarqube-action@v1.2.0
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,16 +67,35 @@ jobs:
     name: SonarQube Trigger
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout sources 🔰
         uses: actions/checkout@v2
         with:
           # Disabling shallow clone is recommended for improving relevancy of reporting
           fetch-depth: 0
-      - name: Install dependencies
-        run: yarn
-      - name: Test and coverage
-        run: yarn jest --coverage
-      - name: SonarQube Scan
+
+      - name: Setup Node.js 16 🧮
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16
+
+      - name: Cache Node.js modules 💾
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+
+      - name: Install dependencies ⏬
+        run: npm ci
+
+      - name: Test code ✅
+        run: npm run test
+        env:
+          CI: true
+
+      - name: SonarQube Scan 🔬
         uses: kitabisa/sonarqube-action@v1.2.0
         with:
           host: ${{ secrets.SONARQUBE_HOST }}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "index.js",
   "scripts": {
     "typecheck": "tsc --project tsconfig.json --noEmit --skipLibCheck",
-    "test": "jest",
+    "test": "jest --coverage",
     "test:watch": "jest --watch",
     "eslint": "eslint -c .eslintrc.js --ext .js,.ts,.tsx",
     "lint": "npm run typecheck && npm run eslint ",


### PR DESCRIPTION
Sets up Node.js, scans the Jest coverage and sends the report to SonarQube.