### PR TITLE
fix: adds missing translation

### DIFF
--- a/assets/formconfigs/application.json
+++ b/assets/formconfigs/application.json
@@ -15,7 +15,8 @@
       "titleId": "ID",
       "titleName": "Name",
       "titleEdit": "Zuletzt editiert am",
-      "titleLink": "Link zur Applikation"
+      "titleLink": "Link zur Applikation",
+      "toolTipLink": "Öffne Applikation"
     },
     "en": {
       "entityName": "Application",
@@ -32,7 +33,9 @@
       "titleId": "ID",
       "titleName": "Name",
       "titleEdit": "Last edited on",
-      "titleLink": "Link to application"
+      "titleLink": "Link to application",
+      "toolTipLink": "Open application"
+
     }
   },
   "endpoint": "/applications",
@@ -151,7 +154,7 @@
         "key": "link",
         "cellRenderComponentName": "LinkCell",
         "cellRenderComponentProps": {
-          "title": "Öffne Applikation",
+          "title": "#i18n.toolTipLink",
           "template": "/client?applicationId={}"
         }
       }

--- a/assets/formconfigs/application.json
+++ b/assets/formconfigs/application.json
@@ -35,7 +35,6 @@
       "titleEdit": "Last edited on",
       "titleLink": "Link to application",
       "toolTipLink": "Open application"
-
     }
   },
   "endpoint": "/applications",
@@ -86,7 +85,7 @@
       },
       {
         "component": "JSONEditor",
-        "dataField": "clientClientConfig",
+        "dataField": "clientConfig",
         "label": "#i18n.labelClientConfig",
         "fieldProps": {
           "entityName": "DefaultApplicationClientConfig"

--- a/src/Component/FormField/LinkField/LinkField.tsx
+++ b/src/Component/FormField/LinkField/LinkField.tsx
@@ -5,21 +5,31 @@ import {
   TooltipProps
 } from 'antd';
 
+import { useTranslation } from 'react-i18next';
+
 import { LinkOutlined } from '@ant-design/icons';
 
 import './LinkField.less';
+import TranslationUtil from '../../../Util/TranslationUtil';
 
 export type LinkFieldProps = {
+  title?: string;
+  i18n?: FormTranslations;
   value: string;
   template?: string;
 } & Partial<TooltipProps>;
 
 export const LinkField: React.FC<LinkFieldProps> = ({
+  i18n,
   value,
   template = '{}',
-  title = 'Öffne Link',
+  title = '',
   ...passThroughProps
 }): JSX.Element => {
+
+  const {
+    t
+  } = useTranslation();
 
   const onClick = () => {
     const link = template.replace(/{}/g, value);
@@ -28,7 +38,7 @@ export const LinkField: React.FC<LinkFieldProps> = ({
 
   return (
     <Tooltip
-      title={title}
+      title={title ? TranslationUtil.getTranslationFromConfig(title, i18n) : t('LinkField.title')}
       {...passThroughProps}
     >
       <div

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.tsx
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { FullscreenExitOutlined, FullscreenOutlined } from '@ant-design/icons';
 import { Button, Tooltip } from 'antd';
+import { useTranslation } from 'react-i18next';
 
 import './FullscreenWrapper.less';
 
@@ -8,6 +9,10 @@ export const FullscreenWrapper: React.FC<React.HTMLAttributes<HTMLDivElement>> =
   children
 }) => {
   const [fullscreen, setFullscreen] = React.useState<boolean>(false);
+
+  const {
+    t
+  } = useTranslation();
 
   const toggleFullscreen = () => {
     setFullscreen(!fullscreen);
@@ -19,7 +24,7 @@ export const FullscreenWrapper: React.FC<React.HTMLAttributes<HTMLDivElement>> =
     <div className={wrapperCls}>
       <div>
         <Tooltip
-          title={`Vollbild ${fullscreen ? ' verlassen' : ''}`}
+          title={fullscreen ? t('FullscreenWrapper.leaveFullscreen') : t('FullscreenWrapper.fullscreen') }
           placement='left'
         >
           <Button

--- a/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
@@ -183,6 +183,7 @@ export function GeneralEntityTable<T extends BaseEntity>({
     if (cellRendererName === 'LinkCell') {
       return (
         <LinkField
+          i18n={i18n}
           value={displayValue}
           {...cellRenderComponentProps}
         />

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -8,6 +8,10 @@ export default {
         loading: 'laden',
         loadFail: 'Die Daten konnten nicht geladen werden. Überprüfen Sie Ihre Konsole.'
       },
+      FullscreenWrapper: {
+        fullscreen: 'Vollbild',
+        leaveFullscreen: 'Vollbild verlassen'
+      },
       WelcomeDashboard: {
         applications: 'Applikationen',
         applicationInfo: '… die die Welt bewegen',
@@ -137,6 +141,10 @@ export default {
       App: {
         loading: 'loading',
         loadFail: 'Failed to load the initial data. Check your console.'
+      },
+      FullscreenWrapper: {
+        fullscreen: 'Fullscreen',
+        leaveFullscreen: 'Leave fullscreen'
       },
       WelcomeDashboard: {
         applications: 'Applications',

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -66,6 +66,9 @@ export default {
         reloadChecked: 'Automatisches Nachladen',
         reloadUnChecked: 'Kein Nachladen'
       },
+      LinkField: {
+        title: 'Öffne Link'
+      },
       Metrics: {
         title: 'Metriken',
         info: '… die die Welt vermessen',
@@ -194,6 +197,9 @@ export default {
         refresh: 'Refresh',
         reloadChecked: 'Live reload',
         reloadUnChecked: 'No reload'
+      },
+      LinkField: {
+        title: 'Open link'
       },
       Metrics: {
         title: 'Metrics',


### PR DESCRIPTION
Adds missing translations.
A check is included, that asks for a title. If no title exists, a default i18n.key will be used.