### PR TITLE
fix: ensures fullscreen for all childs except the first

### DIFF
--- a/src/Component/FullscreenWrapper/FullscreenWrapper.less
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.less
@@ -39,5 +39,10 @@
       border: none;
       box-shadow: none;
     }
+
+    :not(:first-child) {
+      height: 100%;
+      padding-top: 10px;
+    }
   }
 }


### PR DESCRIPTION
Ensures fullscreen for all childs except the first. So the JSON-Editor will be opened in fullscreen

![Peek 2022-08-09 09-48](https://user-images.githubusercontent.com/100765498/183594383-65abba11-63f8-4afe-9386-209c260cc294.gif)
.