### PR TITLE
Fix fullscreen mode again

### DIFF
--- a/src/Component/FormField/JSONEditor/JSONEditor.less
+++ b/src/Component/FormField/JSONEditor/JSONEditor.less
@@ -1,8 +1,5 @@
 .json-editor {
-  height: 200px; // configured editor lineHeight * 10
-  min-height: 40px; // configured editor lineHeight * 2
-  resize: vertical;
-  overflow: hidden;
+  height: 100%;
 
   section {
     border: 1px solid #dedede;

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.less
@@ -1,0 +1,16 @@
+.w-md-editor {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+
+  .w-md-editor-toolbar-divider:last-of-type,
+  .w-md-editor-bar {
+    display: none;
+  }
+}
+
+.fullscreen {
+  .w-md-editor-content {
+    flex: 1;
+  }
+}

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
@@ -2,6 +2,8 @@ import React, { useEffect } from 'react';
 import MDEditor, { ICommand } from '@uiw/react-md-editor';
 import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
 
+import './MarkdownEditor.less';
+
 export type MarkdownEditorProps = {
   value?: string;
   onChange?: (value: string) => void;

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.less
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.less
@@ -4,8 +4,16 @@
   flex-direction: column;
   display: flex;
   padding: 10px;
+  resize: vertical;
+  overflow: hidden;
+  min-height: 25vh;
 
   >div {
+    width: 100%;
+    border-bottom: solid 1px #dedede;
+    margin: 0 5px 5px 0;
+    padding-bottom: 5px;
+
     >button {
       float: right;
     }
@@ -38,11 +46,6 @@
     &:focus {
       border: none;
       box-shadow: none;
-    }
-
-    :not(:first-child) {
-      height: 100%;
-      padding-top: 10px;
     }
   }
 }


### PR DESCRIPTION
Reverts https://github.com/terrestris/shogun-admin/pull/117 since it breaks the visibility of the child elements completely, if at least 2 lines in JSON editor are defined.

![image](https://user-images.githubusercontent.com/3939355/184363573-7005d60c-4d75-4e43-8e86-4fc6ee115460.png)

Partially reverts https://github.com/terrestris/shogun-admin/pull/96:
* Restore 100% height of the child elements in the fullscreen mode
* Restore style removing uneeded elements (separator) on markdown toolbar

Please review @terrestris/devs 