### PR TITLE
Fix JSON schemas for array types

### DIFF
--- a/assets/formconfigs/application.json
+++ b/assets/formconfigs/application.json
@@ -89,33 +89,25 @@
         "component": "JSONEditor",
         "dataField": "clientConfig",
         "label": "#i18n.labelClientConfig",
-        "fieldProps": {
-          "entityName": "DefaultApplicationClientConfig"
-        }
+        "fieldProps": {}
       },
       {
         "component": "JSONEditor",
         "dataField": "layerTree",
         "label": "#i18n.labelTree",
-        "fieldProps": {
-          "entityName": "DefaultLayerTree"
-        }
+        "fieldProps": {}
       },
       {
         "component": "JSONEditor",
         "dataField": "layerConfig",
         "label": "#i18n.labelLayerConfig",
-        "fieldProps": {
-          "entityName": "LayerConfig"
-        }
+        "fieldProps": {}
       },
       {
         "component": "JSONEditor",
         "dataField": "toolConfig",
         "label": "#i18n.labelToolConfig",
-        "fieldProps": {
-          "entityName": "DefaultApplicationToolConfig"
-        }
+        "fieldProps": {}
       },
       {
         "component": "UserPermissionGrid",

--- a/assets/formconfigs/layer.json
+++ b/assets/formconfigs/layer.json
@@ -86,25 +86,19 @@
         "component": "JSONEditor",
         "dataField": "clientConfig",
         "label": "#i18n.labelConfig",
-        "fieldProps": {
-          "entityName": "DefaultLayerClientConfig"
-        }
+        "fieldProps": {}
       },
       {
         "component": "JSONEditor",
         "dataField": "sourceConfig",
         "label": "#i18n.labelSource",
-        "fieldProps": {
-          "entityName": "DefaultLayerSourceConfig"
-        }
+        "fieldProps": {}
       },
       {
         "component": "JSONEditor",
         "dataField": "features",
         "label": "#i18n.labelFeat",
-        "fieldProps": {
-          "entityName": "GeoJsonObject"
-        }
+        "fieldProps": {}
       }
     ]
   },

--- a/assets/formconfigs/user.json
+++ b/assets/formconfigs/user.json
@@ -73,23 +73,20 @@
       {
         "component": "JSONEditor",
         "dataField": "providerDetails",
-        "label": "#i18n.labelKeyProvDetail"
+        "label": "#i18n.labelKeyProvDetail",
+        "fieldProps": {}
       },
       {
         "component": "JSONEditor",
         "dataField": "details",
         "label": "#i18n.labelKeyDetail",
-        "fieldProps": {
-          "entityName": "UserDetails"
-        }
+        "fieldProps": {}
       },
       {
         "component": "JSONEditor",
         "dataField": "clientConfig",
         "label": "#i18n.labelSource",
-        "fieldProps": {
-          "entityName": "UserClientConfig"
-        }
+        "fieldProps": {}
       }
     ]
   },

--- a/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
@@ -151,7 +151,13 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
         );
       case 'JSONEditor':
         return (
-          <JSONEditor {...fieldCfg?.fieldProps} />
+          <JSONEditor
+            entityType={entityType}
+            dataField={fieldCfg.dataField}
+            {
+              ...fieldCfg?.fieldProps
+            }
+          />
         );
       case 'DisplayField':
         return (

--- a/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
@@ -258,7 +258,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
 
     return (
       <Form.Item
-        key={dataField}
+        key={`${entityType}-${form.getFieldValue('id')}-${dataField}`}
         name={dataField}
         className={`cls-${dataField}`}
         normalize={copyFieldCfg.component ? getNormalizeFn(dataField) : undefined}

--- a/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
@@ -198,6 +198,7 @@ export function GeneralEntityTable<T extends BaseEntity>({
 
   const getTableColumns = (): ColumnType<T>[] => {
     let cols: GeneralEntityTableColumn<T>[];
+
     if (_isEmpty(tableConfig?.columnDefinition)) {
       cols = [{
         title: t('GeneralEntityTable.columnId'),
@@ -310,6 +311,7 @@ export function GeneralEntityTable<T extends BaseEntity>({
           onClick: () => onRowClick(record)
         };
       }}
+      rowKey={'id'}
       pagination={false}
       {...tablePassThroughProps}
     />


### PR DESCRIPTION
This fixes the generation of the JSON schemas for properties including an array of referenced schemas, e.g. the `toolConfig` of applications which enables the JSON validation for this fields.

Note: The fieldProp `entityName` is no longer needed as the type will be evaluated automatically based on the appropriate `dataField` now.

Please review @terrestris/devs.