### PR TITLE
use docker-public.terrestris.de registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  DOCKER_REGISTRY: nexus.terrestris.de/repository/terrestris-public
+  DOCKER_REGISTRY: docker-public.terrestris.de/terrestris
 
 jobs:
   release:


### PR DESCRIPTION
Switches to docker-public.terrestris.de so the image will be available publicly.

https://github.com/orgs/terrestris/teams/devs Please note.