### PR TITLE
Show app only if the current user has an appropriate role

### DIFF
--- a/assets/fallbackConfig.js
+++ b/assets/fallbackConfig.js
@@ -10,7 +10,10 @@ var shogunApplicationConfig = {
       enabled: true,
       host: 'https://localhost/auth',
       realm: 'SpringBootKeycloak',
-      clientId: 'shogun-admin'
+      clientId: 'shogun-admin',
+      authorizedRoles: [
+        'admin'
+      ]
     }
   },
   models: [

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -1,8 +1,10 @@
 export default {
   de: {
     translation: {
-      Render: {
-        title: 'Die Anwendung konnte nicht geladen werden. Prüfen Sie Ihre Konsole.'
+      Index: {
+        unauthorizedTitle: 'Sie sind nicht berechtigt, diese Seite zu öffnen.',
+        errorTitle: 'Die Anwendung konnte nicht geladen werden. Prüfen Sie Ihre Konsole.',
+        backToLoginButtonText: 'Zurück zum Login'
       },
       App: {
         loading: 'laden',
@@ -162,8 +164,10 @@ export default {
   },
   en: {
     translation: {
-      Render: {
-        title: 'Failed to load the application. Check your console.'
+      Index: {
+        unauthorizedTitle: 'You\'re not authorized to access this page.',
+        errorTitle: 'Failed to load the application. Check your console.',
+        backToLoginButtonText: 'Back to login'
       },
       App: {
         loading: 'loading',


### PR DESCRIPTION
This suggests to introduce a check for authorized roles before showing the `<App>` component. 

Even if logged in, a user must not have the legitimate role to actually access the SHOGun interfaces and typically only users with the `admin` role are intended to open the admin UI.

Please note the update of the config file for implementing this feature!

Please review @terrestris/devs.