### PR TITLE
Properly reset the dirty state of the entity form

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -152,6 +152,8 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   useEffect(() => {
     if (!entityId) {
       setId(undefined);
+      setEditEntity(undefined);
+      setFormIsDirty(false);
       return;
     }
     if (entityId === 'create') {
@@ -160,6 +162,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
       form.resetFields();
     } else {
       setId(parseInt(entityId, 10));
+      setFormIsDirty(false);
     }
   }, [entityId, form]);
 
@@ -220,6 +223,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
       });
     } finally {
       setIsSaving(false);
+      setFormIsDirty(false);
     }
   };
 

--- a/src/Controller/ControllerUtil.ts
+++ b/src/Controller/ControllerUtil.ts
@@ -28,7 +28,6 @@ export class ControllerUtil {
     formConfig,
     updateForm
   }: ControllerCfg): GenericEntityController<BaseEntity> {
-
     switch (_lowerCase(entityType)) {
       case 'application':
         return ControllerUtil


### PR DESCRIPTION
This properly resets the `formIsDirty` and `editEntity` states to always reflect the correct form state, e.g. to (de-)activate the save button.

Please review @terrestris/devs.