### PR TITLE
Show suggestions for `layerId` fields in the JSON editor

### DIFF
--- a/src/Component/FormField/JSONEditor/JSONEditor.tsx
+++ b/src/Component/FormField/JSONEditor/JSONEditor.tsx
@@ -1,38 +1,28 @@
 import React, {
   useEffect,
-  useState
+  useState,
+  useMemo,
+  useCallback
 } from 'react';
 
 import Editor, {
   EditorProps,
-  Monaco
+  useMonaco
 } from '@monaco-editor/react';
 
 import Logger from 'js-logger';
 
-import {
-  OpenAPIV3
-} from 'openapi-types';
-
-import {
-  JSONSchema7,
-  JSONSchema7Definition,
-  validate
-} from 'json-schema';
-
 import cloneDeep from 'lodash/cloneDeep';
 
 import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
+
+import OpenAPIUtil from '../../../Util/OpenAPIUtil';
 
 import {
   swaggerDocs
 } from '../../../State/static';
 
 import './JSONEditor.less';
-
-type JSONSchemaDefinition = {
-  [key: string]: JSONSchema7Definition;
-};
 
 export type JSONEditorProps = {
   value?: string;
@@ -50,6 +40,43 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
   dataField
 }) => {
   const [currentValue, setCurrentValue] = useState<string>();
+
+  const monaco = useMonaco();
+
+  const openApiUtil = useMemo(() => new OpenAPIUtil({
+    document: swaggerDocs
+  }), []);
+
+  const registerSchemaValidation = useCallback(() => {
+    if (!monaco) {
+      return undefined;
+    }
+
+    const propertyRefName = openApiUtil.getPropertyRefName(entityType, dataField);
+    const schema = openApiUtil.getJSONSchemaFromDocument(propertyRefName, entityType, dataField);
+
+    const schemas = [
+      ...cloneDeep(monaco.languages.json.jsonDefaults.diagnosticsOptions.schemas),
+      {
+        uri: schema.$id,
+        fileMatch: [`${propertyRefName}.json`],
+        schema: schema
+      }
+    ];
+
+    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
+      enableSchemaRequest: true,
+      validate: true,
+      trailingCommas: 'error',
+      schemaValidation: 'error',
+      comments: 'error',
+      schemas: schemas
+    });
+  }, [monaco, dataField, entityType, openApiUtil]);
+
+  useEffect(() => {
+    registerSchemaValidation();
+  }, [registerSchemaValidation]);
 
   useEffect(() => {
     if (!value) {
@@ -78,208 +105,18 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
     }
   };
 
-  const getEntityTypeDefinition = () => {
-    const entry = Object.entries(swaggerDocs.components.schemas)
-      .find(([definitionKey]) => definitionKey.toLowerCase() === entityType.toLowerCase());
-
-    if (!entry) {
-      Logger.warn(`The entity definition for ${entityType} does not exist `+
-        'in the OpenAPI specification');
-
-      return undefined;
-    }
-
-    return entry[1];
-  };
-
-  const getDataTypeDefinition = () => {
-    const entityTypeDefinition = getEntityTypeDefinition();
-
-    if (!entityTypeDefinition) {
-      return undefined;
-    }
-
-    const schemaObject = entityTypeDefinition as OpenAPIV3.SchemaObject;
-
-    if (!schemaObject.properties || !schemaObject.properties[dataField]) {
-      Logger.warn(`The property definition ${dataField} for ${entityType} ` +
-        'does not exist in the OpenAPI specification');
-
-      return undefined;
-    }
-
-    return schemaObject.properties[dataField];
-  };
-
-  const getEntityName = (): string => {
-    const dataFieldDefinition = getDataTypeDefinition();
-
-    if (Object.hasOwn(dataFieldDefinition, '$ref')) {
-      return getRefName(dataFieldDefinition as OpenAPIV3.ReferenceObject);
-    }
-
-    if (Object.hasOwn(dataFieldDefinition, 'items')) {
-      const schemaObject = dataFieldDefinition as OpenAPIV3.ArraySchemaObject;
-
-      if (Object.hasOwn(schemaObject.items, '$ref')) {
-        return getRefName(schemaObject.items as OpenAPIV3.ReferenceObject);
-      }
-    }
-
-    return dataField;
-  };
-
-  const getRefName = (definition: OpenAPIV3.ReferenceObject) => {
-    const splitParts = definition.$ref?.split('/');
-
-    return splitParts[splitParts.length - 1];
-  };
-
-  const getEntityType = (): string => {
-    const dataFieldDefinition = getDataTypeDefinition();
-
-    if (Object.hasOwn(dataFieldDefinition, 'type')) {
-      return (dataFieldDefinition as OpenAPIV3.SchemaObject).type;
-    }
-
-    return 'object';
-  };
-
-  const replaceRefs = (definition: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject) => {
-    if (Object.hasOwn(definition, '$ref')) {
-      replaceRef(definition as OpenAPIV3.ReferenceObject);
-    } else {
-      const schemaObject = definition as OpenAPIV3.SchemaObject;
-      const type = schemaObject.type;
-
-      if (schemaObject.properties) {
-        Object.values(schemaObject.properties).forEach(property => {
-          replaceRefs(property);
-        });
-      }
-
-      if (schemaObject.allOf) {
-        schemaObject.allOf.forEach(def => {
-          replaceRefs(def);
-        });
-      }
-
-      if (schemaObject.anyOf) {
-        schemaObject.anyOf.forEach(def => {
-          replaceRefs(def);
-        });
-      }
-
-      if (schemaObject.oneOf) {
-        schemaObject.oneOf.forEach(def => {
-          replaceRefs(def);
-        });
-      }
-
-      if (schemaObject.not) {
-        replaceRefs(schemaObject.not);
-      }
-
-      if (type === 'array') {
-        replaceRefs(schemaObject.items);
-      }
-    }
-  };
-
-  const replaceRef = (referenceObject: OpenAPIV3.ReferenceObject) => {
-    const splitParts = referenceObject.$ref.split('/');
-    referenceObject.$ref = `#/definitions/${splitParts[splitParts.length - 1]}`;
-  };
-
-  const createDefinitions = (): JSONSchemaDefinition => {
-    const definitions: JSONSchemaDefinition = {};
-
-    for (const schemaName in swaggerDocs.components.schemas) {
-      // Ignore the revision types, e.g. Revisions«int,Application»
-      if (schemaName.match(/^(.+)«(.+)»$/)) {
-        continue;
-      }
-
-      let definition = cloneDeep(swaggerDocs.components.schemas[schemaName]);
-
-      replaceRefs(definition);
-
-      definitions[schemaName] = definition as JSONSchema7;
-    }
-
-    return definitions;
-  };
-
-  const getSchema = (schemaName: string): JSONSchema7 => {
-    const schemaId = `http://shogun/shogun-schema-${schemaName.toLocaleLowerCase()}.json`;
-    const schemaDialect = 'http://json-schema.org/draft-07/schema#';
-    const definitions = createDefinitions();
-    const type = getEntityType();
-
-    let schema: JSONSchema7 = {
-      $id: schemaId,
-      $schema: schemaDialect,
-      definitions: definitions
-    };
-    let isValid;
-
-    if (type === 'object') {
-      schema = {
-        ...schema,
-        ...definitions[schemaName] as {}
-      };
-      isValid = validate({}, schema);
-    }
-
-    if (type === 'array') {
-      schema.items = definitions[schemaName] as {};
-      schema.type = 'array';
-      isValid = validate([], schema);
-    }
-
-    if (!isValid.valid) {
-      Logger.error('Invalid JSON schema detected: ', isValid.errors);
-    }
-
-    return schema;
-  };
-
-  const setSchemaValidation = (monaco: Monaco) => {
-    const entityName = getEntityName();
-    const schema = getSchema(entityName);
-
-    const schemas = [
-      ...cloneDeep(monaco.languages.json.jsonDefaults.diagnosticsOptions.schemas),
-      {
-        uri: schema.$id,
-        fileMatch: [`${entityName}.json`],
-        schema: schema
-      }
-    ];
-
-    monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
-      enableSchemaRequest: true,
-      validate: true,
-      trailingCommas: 'error',
-      schemaValidation: 'error',
-      comments: 'error',
-      schemas: schemas
-    });
-  };
-
-  const onEditorMount = (monaco: Monaco) => {
-    setSchemaValidation(monaco);
-  };
-
   return (
     <FullscreenWrapper>
       <div className='json-editor'>
         <Editor
           value={currentValue}
           onChange={changeHandler}
-          path={getEntityName() ? `${getEntityName()}.json` : undefined}
+          path={
+            openApiUtil.getPropertyRefName(entityType, dataField) ?
+              `${openApiUtil.getPropertyRefName(entityType, dataField)}.json` :
+              undefined
+          }
           language="json"
-          beforeMount={onEditorMount}
           options={{
             lineHeight: 20,
             scrollBeyondLastLine: false

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -102,6 +102,7 @@ export type GeneralEntityConfigType<T extends BaseEntity> = {
   subTitle?: string;
   formConfig: FormConfig;
   tableConfig: TableConfig<T>;
+  onEntitiesLoaded?: (entities: T[], entityType: string) => void;
 };
 
 type OwnProps<T extends BaseEntity> = GeneralEntityConfigType<T>;
@@ -116,7 +117,8 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   navigationTitle = 'Entitäten',
   subTitle = '… mit denen man Dinge tun kann (aus Gründen bspw.)',
   formConfig,
-  tableConfig = {}
+  tableConfig = {},
+  onEntitiesLoaded = () => {}
 }: GeneralEntityRootProps<T>) {
 
   const location = useLocation();
@@ -137,6 +139,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   const [isUploadingFile, setIsUploadingFile] = useState<boolean>(false);
 
   const [form] = Form.useForm();
+
   const client = useSHOGunAPIClient();
 
   const {
@@ -196,8 +199,9 @@ export function GeneralEntityRoot<T extends BaseEntity>({
     setGridLoading(true);
     const allEntries: T[] = await entityController?.findAll();
     setEntities(allEntries || []);
+    onEntitiesLoaded(allEntries, entityType);
     setGridLoading(false);
-  }, [entityController]);
+  }, [entityController, onEntitiesLoaded, entityType]);
 
   /**
    * Fetch entity or create new one

--- a/src/State/atoms.ts
+++ b/src/State/atoms.ts
@@ -3,6 +3,7 @@ import {
 } from 'recoil';
 import { AppInfo } from '@terrestris/shogun-util/dist/model/AppInfo';
 import User from '@terrestris/shogun-util/dist/model/User';
+import Layer from '@terrestris/shogun-util/dist/model/Layer';
 
 export const appInfoAtom = atom<AppInfo>({
   key: 'appInfo',
@@ -25,4 +26,9 @@ export const userInfoAtom = atom<User>({
 export const shogunInfoModalVisibleAtom = atom<boolean>({
   key: 'shogunInfoVisible',
   default: false
+});
+
+export const layerSuggestionListAtom = atom<Layer[]>({
+  key: 'layerSuggestionList',
+  default: null
 });

--- a/src/Util/OpenAPIUtil.ts
+++ b/src/Util/OpenAPIUtil.ts
@@ -1,0 +1,199 @@
+import Logger from 'js-logger';
+
+import {
+  OpenAPIV3
+} from 'openapi-types';
+
+import {
+  JSONSchema7,
+  JSONSchema7Definition,
+  validate,
+  ValidationResult
+} from 'json-schema';
+
+import cloneDeep from 'lodash/cloneDeep';
+
+export type JSONSchemaDefinition = {
+  [key: string]: JSONSchema7Definition;
+};
+
+export type OpenAPIUtilOpts = {
+  document: OpenAPIV3.Document;
+};
+
+export class OpenAPIUtil {
+
+  private document: OpenAPIV3.Document;
+
+  constructor(opts: OpenAPIUtilOpts) {
+    this.document = opts.document;
+  };
+
+  getEntityDefinition = (entity: string) => {
+    const entry = Object.entries(this.document.components.schemas)
+      .find(([definitionKey]) => definitionKey.toLowerCase() === entity.toLowerCase());
+
+    if (!entry) {
+      Logger.warn(`The entity definition for ${entity} does not exist `+
+        'in the OpenAPI specification');
+
+      return undefined;
+    }
+
+    return entry[1];
+  };
+
+  getPropertyDefinition = (entity: string, property: string) => {
+    const entityDefinition = this.getEntityDefinition(entity);
+
+    if (!entityDefinition) {
+      return undefined;
+    }
+
+    const schemaObject = entityDefinition as OpenAPIV3.SchemaObject;
+
+    if (!schemaObject.properties || !schemaObject.properties[property]) {
+      Logger.warn(`The property definition ${property} for ${entity} ` +
+        'does not exist in the OpenAPI specification');
+
+      return undefined;
+    }
+
+    return schemaObject.properties[property];
+  };
+
+  getPropertyRefName = (entity: string, property: string) => {
+    const propertyDefinition = this.getPropertyDefinition(entity, property);
+
+    if (Object.hasOwn(propertyDefinition, '$ref')) {
+      return this.getRefName(propertyDefinition as OpenAPIV3.ReferenceObject);
+    }
+
+    if (Object.hasOwn(propertyDefinition, 'items')) {
+      const schemaObject = propertyDefinition as OpenAPIV3.ArraySchemaObject;
+
+      if (Object.hasOwn(schemaObject.items, '$ref')) {
+        return this.getRefName(schemaObject.items as OpenAPIV3.ReferenceObject);
+      }
+    }
+
+    return property;
+  };
+
+  getPropertyType = (entity: string, property: string): string => {
+    const propertyDefinition = this.getPropertyDefinition(entity, property);
+
+    if (Object.hasOwn(propertyDefinition, 'type')) {
+      return (propertyDefinition as OpenAPIV3.SchemaObject).type;
+    }
+
+    return 'object';
+  };
+
+  getJSONSchemaFromDocument = (schemaName: string, entity: string, property: string): JSONSchema7 => {
+    const schemaId = `http://shogun/shogun-schema-${schemaName.toLocaleLowerCase()}.json`;
+    const schemaDialect = 'http://json-schema.org/draft-07/schema#';
+    const definitions = this.createDefinitions();
+    const type = this.getPropertyType(entity, property);
+
+    let schema: JSONSchema7 = {
+      $id: schemaId,
+      $schema: schemaDialect,
+      definitions: definitions
+    };
+    let isValid: ValidationResult;
+
+    if (type === 'object') {
+      schema = {
+        ...schema,
+        ...definitions[schemaName] as {}
+      };
+      isValid = validate({}, schema);
+    }
+
+    if (type === 'array') {
+      schema.items = definitions[schemaName] as {};
+      schema.type = 'array';
+      isValid = validate([], schema);
+    }
+
+    if (!isValid.valid) {
+      Logger.error('Invalid JSON schema detected: ', isValid.errors);
+    }
+
+    return schema;
+  };
+
+  private createDefinitions = (): JSONSchemaDefinition => {
+    const definitions: JSONSchemaDefinition = {};
+
+    for (const schemaName in this.document.components.schemas) {
+      // Ignore the revision types, e.g. Revisions«int,Application»
+      if (schemaName.match(/^(.+)«(.+)»$/)) {
+        continue;
+      }
+
+      let definition = cloneDeep(this.document.components.schemas[schemaName]);
+
+      this.replaceRefs(definition);
+
+      definitions[schemaName] = definition as JSONSchema7;
+    }
+
+    return definitions;
+  };
+
+  private getRefName = (definition: OpenAPIV3.ReferenceObject) => {
+    const splitParts = definition.$ref?.split('/');
+
+    return splitParts[splitParts.length - 1];
+  };
+
+  private replaceRefs = (definition: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject) => {
+    if (Object.hasOwn(definition, '$ref')) {
+      this.replaceRef(definition as OpenAPIV3.ReferenceObject);
+    } else {
+      const schemaObject = definition as OpenAPIV3.SchemaObject;
+      const type = schemaObject.type;
+
+      if (schemaObject.properties) {
+        Object.values(schemaObject.properties).forEach(property => {
+          this.replaceRefs(property);
+        });
+      }
+
+      if (schemaObject.allOf) {
+        schemaObject.allOf.forEach(def => {
+          this.replaceRefs(def);
+        });
+      }
+
+      if (schemaObject.anyOf) {
+        schemaObject.anyOf.forEach(def => {
+          this.replaceRefs(def);
+        });
+      }
+
+      if (schemaObject.oneOf) {
+        schemaObject.oneOf.forEach(def => {
+          this.replaceRefs(def);
+        });
+      }
+
+      if (schemaObject.not) {
+        this.replaceRefs(schemaObject.not);
+      }
+
+      if (type === 'array') {
+        this.replaceRefs(schemaObject.items);
+      }
+    }
+  };
+
+  private replaceRef = (referenceObject: OpenAPIV3.ReferenceObject) => {
+    const splitParts = referenceObject.$ref.split('/');
+    referenceObject.$ref = `#/definitions/${splitParts[splitParts.length - 1]}`;
+  };
+}
+
+export default OpenAPIUtil;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,10 @@ import {
 
 import Keycloak from 'keycloak-js';
 
+import {
+  loader
+} from '@monaco-editor/react';
+
 import Logger from './Logger';
 
 import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
@@ -102,6 +106,12 @@ const renderApp = async () => {
     }
 
     const client = initSHOGunAPIClient(keycloak);
+
+    loader.config({
+      paths: {
+        vs: './vs'
+      }
+    });
 
     root.render(
       <SHOGunAPIClientProvider client={client}>

--- a/webpack.common.config.js
+++ b/webpack.common.config.js
@@ -85,14 +85,15 @@ module.exports = {
       patterns: [{
         from: './assets/formconfigs/',
         to: 'formconfigs'
-      },
-      {
+      }, {
         from: './assets/img/',
         to: 'img'
-      },
-      {
+      }, {
         from: './assets/fallbackConfig.js',
         to: 'fallbackConfig.js'
+      },{
+        from: './node_modules/monaco-editor/min/vs',
+        to: 'vs'
       }],
     }),
     new webpack.DefinePlugin({


### PR DESCRIPTION
This adds a completion provider for the `JSONEditor` that resolves the value of all `layerId` fields in the editor with the actual layer name (and the full JSON config object as documentation).

![Peek 2023-01-06 10-48](https://user-images.githubusercontent.com/1137620/210975601-c9594629-584e-4ee4-9137-e0635a658ecf.gif)

Please review @terrestris/devs.