### PR TITLE
Send undefined values to the backend

### DIFF
--- a/src/Controller/GenericEntityController.ts
+++ b/src/Controller/GenericEntityController.ts
@@ -142,7 +142,7 @@ export class GenericEntityController<T extends BaseEntity> {
     }
 
     this.entity = isUpdate ?
-      await this.service?.updatePartial(entityUpdateObject) :
+      await this.service?.update(entityUpdateObject as T) :
       await this.service.add(entityUpdateObject as T);
 
     return this.entity;


### PR DESCRIPTION
Undefined Values can now be send to the Backend due to a change of the request method.