### PR TITLE
fix: resets the input form to the initial value

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -269,9 +269,14 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   };
 
   const onResetForm = () => {
-    form?.resetFields();
+    const oldValues = allEntities.find((entity) => entity.id === id);
+    if (!oldValues) {
+      return;
+    }
+
+    form.resetFields();
+    form.setFieldsValue(oldValues);
     setFormIsDirty(false);
-    entityController.createEntity();
   };
 
   const onSaveClick = async () => {


### PR DESCRIPTION
The function `form.resetFields()` creates an empty object, the form value needs to be replaced with the initial value after clearing the input.