### PR TITLE
Fix infinite reload loop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -71,7 +71,8 @@ const initKeycloak = async (): Promise<Keycloak | null> => {
   };
 
   await keycloak.init({
-    onLoad: 'login-required'
+    onLoad: 'login-required',
+    checkLoginIframe: false
   });
 
   return keycloak;


### PR DESCRIPTION
This fixes the reloading loop in some browsers (e.g. Firefox) by disabling checking the login status in an iframe.

See [here](https://www.keycloak.org/docs/latest/securing_apps/index.html#session-status-iframe) for further details.

Please review @terrestris/devs.