### PR TITLE
Several fixes to the logs page

### DIFF
--- a/src/Component/Logs/Logs.less
+++ b/src/Component/Logs/Logs.less
@@ -1,8 +1,16 @@
 .log-root {
-  height: 100%;
-  overflow: auto;
+  .log-container {
+    padding: 0 0 0 24px;
 
-  textarea.ant-input.logs {
-    flex: 1;
+    .ant-alert {
+      margin-right: 24px;
+    }
+
+    pre {
+      white-space: pre-wrap;
+      overflow-wrap: anywhere;
+      overflow: auto;
+      max-height: calc(100vh - 142px);
+    }
   }
 }

--- a/src/Service/LogService/LogService.ts
+++ b/src/Service/LogService/LogService.ts
@@ -82,13 +82,18 @@ class LogService {
     }
   };
 
-  async getLogs(): Promise<string> {
+  async getLogs() {
     try {
       const logResponse = await fetch(`${config.path.shogunBase}actuator/logfile`, {
         headers: {
           ...getBearerTokenHeader(this.keycloak)
         }
       });
+
+      if (!logResponse.ok) {
+        throw new Error('No successful response while getting the logs');
+      }
+
       const logText = await logResponse.text();
 
       return logText;

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -105,7 +105,10 @@ export default {
         logsInfo: '… die die Welt erklären',
         refresh: 'Aktualisieren',
         reloadChecked: 'Automatisches Nachladen',
-        reloadUnChecked: 'Kein Nachladen'
+        reloadUnChecked: 'Kein Nachladen',
+        warningMessage: 'Logs können nicht angezeigt werden',
+        warningDescribtion: 'Hinweis: Um die Logs anzeigen zu können ist es notwendig, dass die ' +
+          'Logs in eine Datei geschrieben werden. Bitte die SHOGun API Konfiguration entsprechend überprüfen.'
       },
       LinkField: {
         title: 'Öffne Link'
@@ -311,7 +314,10 @@ export default {
         logsInfo: '… that explain the world',
         refresh: 'Refresh',
         reloadChecked: 'Live reload',
-        reloadUnChecked: 'No reload'
+        reloadUnChecked: 'No reload',
+        warningMessage: 'Error while displaying the logs',
+        warningDescribtion: 'Note: In order to be able to display the logs, it is necessary that the logs ' +
+          'are written to a file. Please check the SHOGun API configuration accordingly.'
       },
       LinkField: {
         title: 'Open link'


### PR DESCRIPTION
This suggests to apply several minor fixes to the logs page:

- Fix disabling of the automatic log refresh.
- Adjust styling to show the full scrollbar and show a loading indicator.
- Replace the `TextArea` with a `pre` element.
- Add a note if the log can't be shown.

Preview:

![image](https://github.com/terrestris/shogun-admin/assets/1137620/8aaa043c-6e88-4493-83d7-432c9a3eb1c8)

![image](https://github.com/terrestris/shogun-admin/assets/1137620/6af565d4-e177-49da-822a-f014056a1cef)

Please review @terrestris/devs.
