### PR TITLE
Init `VerifyProviderDetailsField` cell renderer

### DIFF
--- a/assets/formconfigs/group.json
+++ b/assets/formconfigs/group.json
@@ -9,6 +9,7 @@
       "labelKey": "Keycloak ID",
       "titleId": "ID",
       "titleKeyId": "Keycloak ID",
+      "userDoesNotExistTitle": "Die Gruppe existiert nicht in Keycloak",
       "titleLink": "Link zur Gruppe",
       "titleGroup": "Öffne Gruppe in Keycloak"
     },
@@ -21,6 +22,7 @@
       "labelKey": "Keycloak ID",
       "titleId": "ID",
       "titleKeyId": "Keycloak ID",
+      "userDoesNotExistTitle": "Group does not exist in Keycloak",
       "titleLink": "Link to group",
       "titleGroup": "Open group in Keycloak"
     }
@@ -79,6 +81,10 @@
         "title": "#i18n.titleKeyId",
         "dataIndex": "authProviderId",
         "key": "authProviderId",
+        "cellRenderComponentName": "VerifyProviderDetailsCell",
+        "cellRenderComponentProps": {
+          "title": "#i18n.groupDoesNotExistTitle"
+        },
         "sortConfig": {
           "isSortable": true
         },

--- a/assets/formconfigs/user.json
+++ b/assets/formconfigs/user.json
@@ -12,6 +12,7 @@
       "labelSource": "Datenquelle",
       "titleId": "ID",
       "titleKeyId": "Keycloak ID",
+      "userDoesNotExistTitle": "Der Nutzer existiert nicht in Keycloak",
       "titleLink": "Link zum Benutzer",
       "titleOpen": "Öffne User in Keycloak"
     },
@@ -27,6 +28,7 @@
       "labelSource": "Datasource",
       "titleId": "ID",
       "titleKeyId": "Keycloak ID",
+      "userDoesNotExistTitle": "User does not exist in Keycloak",
       "titleLink": "Link to user",
       "titleOpen": "Open user in Keycloak"
     }
@@ -103,6 +105,10 @@
         "title": "#i18n.titleKeyId",
         "dataIndex": "authProviderId",
         "key": "authProviderId",
+        "cellRenderComponentName": "VerifyProviderDetailsCell",
+        "cellRenderComponentProps": {
+          "title": "#i18n.userDoesNotExistTitle"
+        },
         "sortConfig": {
           "isSortable": true
         },

--- a/src/Component/FormField/VerifyProviderDetailsField/VerifyProviderDetailsField.less
+++ b/src/Component/FormField/VerifyProviderDetailsField/VerifyProviderDetailsField.less
@@ -1,0 +1,4 @@
+.provider-details-warning {
+  color: #FD7D00;
+  padding-left: 5px;
+}

--- a/src/Component/FormField/VerifyProviderDetailsField/VerifyProviderDetailsField.spec.tsx
+++ b/src/Component/FormField/VerifyProviderDetailsField/VerifyProviderDetailsField.spec.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import {
+  render
+} from '@testing-library/react';
+
+import User from '@terrestris/shogun-util/dist/model/User';
+
+import VerifyProviderDetailsField from './VerifyProviderDetailsField';
+
+describe('<VerifyProviderDetailsField />', () => {
+
+  it('can be rendered', () => {
+    const user = new User({});
+
+    const { container } = render(
+      <VerifyProviderDetailsField
+        value="1234"
+        record={user}
+      />
+    );
+
+    expect(container).toBeVisible();
+  });
+
+  it('shows the provided value (and no warning)', () => {
+    const user = new User({
+      providerDetails: {
+        email: 'test@example.com'
+      }
+    });
+
+    const {
+      queryByText,
+      queryByRole
+    } = render(
+      <VerifyProviderDetailsField
+        value="1234"
+        record={user}
+      />
+    );
+
+    const displayValue = queryByText('1234');
+
+    expect(displayValue).toBeVisible();
+
+    const warningIcon = queryByRole('img');
+
+    expect(warningIcon).toBeNull();
+  });
+
+  it('shows the provided value and a warning if the provider details aren\'t available', () => {
+    const user = new User({});
+
+    const {
+      queryByRole,
+      queryByText
+    } = render(
+      <VerifyProviderDetailsField
+        value="1234"
+        record={user}
+      />
+    );
+
+    const displayValue = queryByText('1234');
+
+    expect(displayValue).toBeVisible();
+
+    const warningIcon = queryByRole('img');
+
+    expect(warningIcon).toBeVisible();
+  });
+
+});

--- a/src/Component/FormField/VerifyProviderDetailsField/VerifyProviderDetailsField.tsx
+++ b/src/Component/FormField/VerifyProviderDetailsField/VerifyProviderDetailsField.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import {
+  ExclamationCircleOutlined
+} from '@ant-design/icons';
+
+import {
+  Tooltip,
+  TooltipProps
+} from 'antd';
+
+import {
+  useTranslation
+} from 'react-i18next';
+
+import Group from '@terrestris/shogun-util/dist/model/Group';
+import User from '@terrestris/shogun-util/dist/model/User';
+
+import TranslationUtil from '../../../Util/TranslationUtil';
+
+import './VerifyProviderDetailsField.less';
+
+export type VerifyProviderDetailsFieldProps = {
+  record: User | Group;
+  value?: string;
+  i18n?: FormTranslations;
+  title?: string;
+} & Partial<Omit<TooltipProps, 'title'>>;
+
+export const VerifyProviderDetailsField: React.FC<VerifyProviderDetailsFieldProps> = ({
+  record,
+  value,
+  i18n,
+  title,
+  ...passThroughProps
+}): JSX.Element => {
+
+  const {
+    t
+  } = useTranslation();
+
+  if (!record.providerDetails) {
+    return (
+      <>
+        <>{value}</>
+        <Tooltip
+          title={title ? TranslationUtil.getTranslationFromConfig(title, i18n) : t('VerifyProviderDetailsField.title')}
+          {...passThroughProps}
+        >
+          <ExclamationCircleOutlined
+            className='provider-details-warning'
+          />
+        </Tooltip>
+      </>
+    );
+  }
+
+  return (<>{value}</>);
+};
+
+export default VerifyProviderDetailsField;

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -772,7 +772,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
               items_per_page: `/ ${t('GeneralEntityTable.paging.itemsPerPage')}`,
               // eslint-disable-next-line camelcase
               jump_to: t('GeneralEntityTable.paging.jumpTo'),
-              page: t('GeneralEntityTable.paging.page'),
+              page: t('GeneralEntityTable.paging.page')
             }
           }}
         />

--- a/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
@@ -38,6 +38,8 @@ import TableUtil from '../../../Util/TableUtil';
 import TranslationUtil from '../../../Util/TranslationUtil';
 import DisplayField from '../../FormField/DisplayField/DisplayField';
 import LinkField from '../../FormField/LinkField/LinkField';
+import VerifyProviderDetailsField from '../../FormField/VerifyProviderDetailsField/VerifyProviderDetailsField';
+
 import LayerPreview from '../../LayerPreview/LayerPreview';
 
 export type TableConfig<T extends BaseEntity> = {
@@ -156,7 +158,7 @@ export function GeneralEntityTable<T extends BaseEntity>({
     });
   };
 
-  const getRenderer = (cellRendererName: string, cellRenderComponentProps: {[key: string]: any},
+  const getRenderer = (cellRendererName: string, cellRenderComponentProps?: {[key: string]: any},
     mapping?: {[key: string]: string}) => (value: any, record: T) => {
     const displayValue = mapping ? mapping[value] : value;
 
@@ -197,6 +199,17 @@ export function GeneralEntityTable<T extends BaseEntity>({
       return (
         <LayerPreview
           layer={record}
+          {...cellRenderComponentProps}
+        />
+      );
+    }
+
+    if (cellRendererName === 'VerifyProviderDetailsCell') {
+      return (
+        <VerifyProviderDetailsField
+          i18n={i18n}
+          value={displayValue}
+          record={record}
           {...cellRenderComponentProps}
         />
       );
@@ -255,7 +268,7 @@ export function GeneralEntityTable<T extends BaseEntity>({
           } as any;
         }
         const mapping = tableConfig.dataMapping?.[dataIndex!];
-        if (!_isEmpty(cellRenderComponentName) && !_isEmpty(mapping) && !_isNil(cellRenderComponentProps)) {
+        if (!_isEmpty(cellRenderComponentName)) {
           columnDef = {
             ...columnDef,
             render: getRenderer(cellRenderComponentName!, cellRenderComponentProps, mapping)

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -204,6 +204,9 @@ export default {
         loadLayerErrorMsg: 'Fehler beim Laden des Layers.',
         extentNotSupportedErrorMsg: 'Zoomen auf Gesamtansicht wird für diesen Typ nicht unterstützt.'
       }
+    },
+    VerifyProviderDetailsField: {
+      title: 'Keine Authentication Provider Informationen verfügbar'
     }
   },
   en: {
@@ -424,6 +427,9 @@ export default {
         addLayerErrorMsg: 'Could not add the layer to the map.',
         loadLayerErrorMsg: 'Error while loading the layer.',
         extentNotSupportedErrorMsg: 'Zoom to layer is not supported for this type.'
+      },
+      VerifyProviderDetailsField: {
+        title: 'No authentication provider informations available'
       }
     }
   }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -206,7 +206,7 @@ export default {
       }
     },
     VerifyProviderDetailsField: {
-      title: 'Keine Authentication Provider Informationen verfügbar'
+      title: 'Keine Informationen des Authentication-Providers verfügbar'
     }
   },
   en: {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -429,7 +429,7 @@ export default {
         extentNotSupportedErrorMsg: 'Zoom to layer is not supported for this type.'
       },
       VerifyProviderDetailsField: {
-        title: 'No authentication provider informations available'
+        title: 'No authentication provider information available'
       }
     }
   }


### PR DESCRIPTION
This includes the cell renderer component `VerifyProviderDetailsField` that can be used to show a warning besides a `User` or `Group` table column cell to show a warning if the user/group is not available in the authentication provider (=Keycloak).

![image](https://github.com/terrestris/shogun-admin/assets/1137620/112390da-4804-4f16-a4ea-a1fd3068a1b1)

To enable it provide a model config (e.g. in the `user.json`) like:

```json
{
  "title": "#i18n.titleKeyId",
  "dataIndex": "authProviderId",
  "key": "authProviderId",
  "cellRenderComponentName": "VerifyProviderDetailsCell",
  "cellRenderComponentProps": {
    "title": "#i18n.userDoesNotExistTitle"
  }
}
```

Please review @terrestris/devs.