### PR TITLE
fix: fixed a bug where Logging-Level Table would not show its values

### DIFF
--- a/src/Component/LogSettings/LogLevelTable/LogLevelTable.tsx
+++ b/src/Component/LogSettings/LogLevelTable/LogLevelTable.tsx
@@ -122,7 +122,7 @@ export const LogLevelTable: React.FC<LogLevelTableProps> = props => {
       <Table
         loading={isLoading}
         columns={columns}
-        dataSource={filteredData === null ? data : filteredData}
+        dataSource={filteredData.length === 0 ? data : filteredData}
         {...props}
       />
     </>


### PR DESCRIPTION
When calling Logging-Level Table the data would not show until the search button was clicked. This was a fault in the condition. This push fixes this issue. 