### PR TITLE
Update webpack dev server configuration

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -18,7 +18,7 @@ module.exports = merge(common, {
     static: [
       path.join(__dirname, 'assets')
     ],
-    allowedHosts: ['.intranet.terrestris.de']
+    historyApiFallback: true
   },
   plugins: [
     new ReactRefreshWebpackPlugin()


### PR DESCRIPTION
This updates the webpack dev server configuration by:

- Removing an internal path.
- Readding the [historyApiFallback](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback) option to make routing work again.

Please review @terrestris/devs.