### PR TITLE
fix: fix setting range for layerId suggestions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -96,6 +96,7 @@ const App: React.FC = () => {
           return undefined;
         }
 
+        const currentWord = model.getWordAtPosition(position);
         const providerResult: ProviderResult<CompletionList> = {
           suggestions: layerSuggestionList.map((layer): CompletionItem => {
             return {
@@ -104,10 +105,11 @@ const App: React.FC = () => {
               kind: monaco.languages.CompletionItemKind.Value,
               documentation: `${JSON.stringify(layer, null, '  ')}`,
               range: {
-                startColumn: 0,
-                startLineNumber: 0,
-                endLineNumber: Number.MAX_SAFE_INTEGER,
-                endColumn: Number.MAX_SAFE_INTEGER
+                // replace the current word, if applicable
+                startColumn: currentWord ? currentWord.startColumn : position.column,
+                endColumn: currentWord ? currentWord.endColumn : position.column,
+                startLineNumber: position.lineNumber,
+                endLineNumber: position.lineNumber,
               }
             };
           })

--- a/src/State/atoms.ts
+++ b/src/State/atoms.ts
@@ -31,5 +31,5 @@ export const shogunInfoModalVisibleAtom = atom<boolean>({
 
 export const layerSuggestionListAtom = atom<Layer[]>({
   key: 'layerSuggestionList',
-  default: []
+  default: undefined
 });


### PR DESCRIPTION
This fixes the suggestions for layerIds by adjusting the range property. Newer versions of monaco-editor require the range to be set and to be a single line range.

The range was adjusted so that suggestions replace the characters of a typed word, if there are any. Otherwise suggestions will just be added to the current cursor position.

This also adjusts the default value of the suggestions, so that they will be fetched when refreshing the application view.

![shogun-layerid-suggestions](https://github.com/terrestris/shogun-admin/assets/12186477/712eb686-47c8-46e0-9b97-199445ec24de)
