### PR TITLE
Fix development server websocket configuration

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,4 +2,6 @@ FROM node:18.18.2-alpine3.17
 
 WORKDIR /app
 
+EXPOSE 8080
+
 ENTRYPOINT ["npm", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ shogun-admin:
   build:
     context: ../shogun-admin
     dockerfile: Dockerfile.dev
-  ports:
-    - 9090:9090
   volumes:
     - ../shogun-admin:/app
 ```
 
 # Semantic release
+
 Allowed Tags for semantic release (see the [FAQs](https://github.com/semantic-release/semantic-release/blob/master/docs/support/FAQ.md) for more information about this):
 
 - Breaking changes: `breaking`

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,6 +1,8 @@
-const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
 const webpack = require('webpack');
+
 const CustomAntThemeModifyVars = require('./theme.js');
 
 module.exports = {

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -12,8 +12,11 @@ module.exports = merge(common, {
   mode: 'development',
   devtool: 'inline-source-map',
   devServer: {
-    server: 'https',
-    port: 9090,
+    server: 'http',
+    port: 8080,
+    client: {
+      webSocketURL: 'http://0.0.0.0:0/admin/ws'
+    },
     hot: true,
     static: [
       path.join(__dirname, 'assets')


### PR DESCRIPTION
This updates the webpack development server configuration by:

- changing the protocol from `https` to `http` (in the [recommended setup](https://github.com/terrestris/shogun-docker) it's proxied by a https server anyway).
- fixing the websocket client path to match the location given in the [nginx](https://github.com/terrestris/shogun-docker/blob/main/shogun-nginx/dev/default.conf#L95) proxy.
- setting the http port to 8080 (not needed in particular to be honest).

Together with [PR 92](https://github.com/terrestris/shogun-docker/pull/92) this fixes the need to manually confirm the development certificate for the web socket connection.

Please review @terrestris/devs.