### PR TITLE
fix: set sonarcube project base directory

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -131,3 +131,5 @@ jobs:
         with:
           host: ${{ secrets.SONARQUBE_HOST }}
           login: ${{ secrets.SONARQUBE_TOKEN }}
+          projectBaseDir: "src/"
+          projectKey: "shogun-admin"


### PR DESCRIPTION
Hopefully, this solves the SonarCube Trigger workflow  that currently fails when a release is performed.

Plz review @terrestris/devs 