### PR TITLE
fix: do not overwrite existing entity

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -332,6 +332,11 @@ export function GeneralEntityRoot<T extends BaseEntity>({
     setFormIsDirty(false);
   };
 
+  const onCreateForm = () => {
+    setEditEntity(undefined);
+    setId('create');
+  };
+
   const onSaveClick = async () => {
     setIsSaving(true);
     try {
@@ -737,7 +742,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
           <Link
             key="create"
             to={`${config.appPrefix}/portal/${entityType}/create`}
-            onClick={onResetForm}
+            onClick={onCreateForm}
           >
             <Button
               type="primary"


### PR DESCRIPTION
This fixes a serious bug that ensures that an existing entity (app or layer) will not be overwritten/lost. The bug could be reproduced by

1. Open (generic) form of an entity
2. Click on "Create new ..." 
3. Set basic value like name
4. Click save

After that, the entity opened in step 1 is fully lost/overwritten.