### PR TITLE
fix: sort and filter for every entity and pagination

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -173,6 +173,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
     setPageCurrent(1);
     setSortOrder('ascend');
     setSortField(undefined);
+    setFiltered(false); // to always obtain pagination when changing the entity
   }, [entityType]);
 
   /**

--- a/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityTable/GeneralEntityTable.tsx
@@ -326,6 +326,7 @@ export function GeneralEntityTable<T extends BaseEntity>({
       }}
       rowKey={'id'}
       {...tablePassThroughProps}
+      key={entityType}
     />
   );
 }


### PR DESCRIPTION
1) Filter and sorting as well are now individual for every entity by adding the key to the table. Beforehand the filter and sorting were active for every entity.
2) The pagination element is now loaded when changing the entity. Beforehand it disappeared when the reset button wasn't clicked.

@mholthausen 