### PR TITLE
Use node LTS (v20.12.1) and alpine 3.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build environment
-FROM node:18.18.2-alpine3.17 AS build
+FROM node:20.12.1-alpine3.19 AS build
 
 WORKDIR /app
 
@@ -8,7 +8,7 @@ RUN npm ci
 RUN npm run build
 
 # production environment
-FROM nginx:1.25.3-alpine-slim
+FROM nginx:1.25.4-alpine-slim
 
 COPY --from=build /app/dist /var/www/html
 COPY --from=build /app/nginx/templates /etc/nginx/templates

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18.18.2-alpine3.17
+FROM node:20.12.1-alpine3.19
 
 WORKDIR /app
 


### PR DESCRIPTION
This PR updates the Dockerfiles to use the current Nodejs LTS version (`20.12.1`), `alpine3.19` and `nginx1.25.4`

@terrestris/core please review