### PR TITLE
docs: add test-coverage summary report as comment

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -33,7 +33,19 @@ jobs:
       - name: Typecheck code 👓
         run: npm run typecheck
 
-      - name: Test code ✅
-        run: npm run test
-        env:
-          CI: true
+      - name: Test code and build artifacts ✅
+        run: npm run build
+
+      - name: Run tests related to current changes
+        run: |
+          npx jest --collectCoverageFrom='["**/*.{ts,tsx,js,jsx}"]' --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
+
+      - name: Jest Coverage Comment
+        uses: MishaKav/jest-coverage-comment@main
+        with:
+          hide-comment: false
+          create-new-comment: false
+          hide-summary: false
+          multiple-files: |
+            All, ./coverage/all/coverage-summary.json
+            only changed, ./coverage/changed/coverage-summary.json

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Test code and build artifacts ✅
         run: npm run build
 
-      - name: Run tests related to current changes
+      - name: Run tests related to current changes ✅
         run: |
           npx jest --collectCoverageFrom='["**/*.{ts,tsx,js,jsx}"]' --coverage --coverageReporters json-summary --onlyChanged --coverageDirectory ./coverage/changed
 
-      - name: Jest Coverage Comment
+      - name: Jest Coverage Comment 💬
         uses: MishaKav/jest-coverage-comment@main
         with:
           hide-comment: false

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -7,10 +7,6 @@ async function globalSetup(config: FullConfig) {
   process.env.ID = '20';
   // @ts-ignore
   process.env.HOST = 'https://shogun2022.intranet.terrestris.de';
-  // @ts-ignore
-  process.env.ADMIN_LOGIN = 'shogun';
-  // @ts-ignore
-  process.env.ADMIN_PASSWORD = 'shogun';
 }
 
 export default globalSetup;

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -7,6 +7,10 @@ async function globalSetup(config: FullConfig) {
   process.env.ID = '20';
   // @ts-ignore
   process.env.HOST = 'https://shogun2022.intranet.terrestris.de';
+  // @ts-ignore
+  process.env.ADMIN_LOGIN = 'shogun';
+  // @ts-ignore
+  process.env.ADMIN_PASSWORD = 'shogun';
 }
 
 export default globalSetup;

--- a/jest.config.js
+++ b/jest.config.js
@@ -36,7 +36,9 @@ const config = {
     'json'
   ],
   testEnvironment: 'jsdom',
-  reporters: ['default', '@casualbot/jest-sonar-reporter']
+  reporters: ['default', '@casualbot/jest-sonar-reporter'],
+  coverageReporters: ['json-summary'],
+  coverageDirectory: 'coverage/all'
 };
 
 module.exports = config;


### PR DESCRIPTION
This uses the following action https://github.com/marketplace/actions/jest-coverage-comment to comment on each new pull request with a HTML test coverage report (for entire repo, as well as for changed code (will return unknown, if no tests are found))

Also removes setting of the ci-environment variable as this is done by default (see: https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/).