### PR TITLE
test: change sonarqube configuration to cause analysis to fail when quality gate fails

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,3 +2,6 @@ sonar.projectBaseDir=/home/runner/work/shogun-admin/shogun-admin
 sonar.testExecutionReportPaths=./coverage/jest-report.xml
 sonar.tests=src
 sonar.test.inclusions=**/*.spec.tsx,**/*.spec.ts
+
+# quality gate rules
+sonar.qualitygate.wait=true


### PR DESCRIPTION
This sets the sonar.qualitygate.wait=true parameter which forces the sonarqube step to poll the SonarQube instance until the quality gate status is available.
It causes the sonarqube analysis step to fail any time the quality gate fails.

Also increases the pipeline duration!