### PR TITLE
feat: configurable layer import

### DIFF
--- a/assets/formconfigs/layer.json
+++ b/assets/formconfigs/layer.json
@@ -38,6 +38,7 @@
   "entityName": "#i18n.entityName",
   "navigationTitle": "#i18n.navigationTitle",
   "subTitle": "",
+  "importEnabled": true,
   "formConfig": {
     "name": "layer",
     "fields": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@ant-design/pro-components": "^2.7.10",
         "@casualbot/jest-sonar-reporter": "2.4.0",
         "@monaco-editor/react": "4.6.0",
-        "@rollup/rollup-linux-x64-gnu": "4.24.0",
         "@terrestris/base-util": "2.0.0",
         "@terrestris/ol-util": "19.0.1",
         "@terrestris/shogun-util": "9.0.0",

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -76,12 +76,11 @@ import {
 } from '../../../Controller/GenericEntityController';
 import useSHOGunAPIClient from '../../../Hooks/useSHOGunAPIClient';
 import TranslationUtil from '../../../Util/TranslationUtil';
-import GeneralEntityForm, {
-  FormConfig
-} from '../GeneralEntityForm/GeneralEntityForm';
+import GeneralEntityForm from '../GeneralEntityForm/GeneralEntityForm';
 import GeneralEntityTable, {
   TableConfig
 } from '../GeneralEntityTable/GeneralEntityTable';
+import {FormConfig} from "antd/es/config-provider/context";
 
 type LayerUploadOptions = {
   baseUrl: string;
@@ -109,17 +108,17 @@ type FeatureTypeAttributes = {
 };
 
 export type GeneralEntityConfigType<T extends BaseEntity> = {
-  i18n: FormTranslations;
+  defaultEntity?: T;
   endpoint: string;
+  entityName?: string;
+  formConfig?: FormConfig;
   entityType: string;
   defaultSortField?: string;
-  entityName?: string;
+  importEnabled?: boolean;
   navigationTitle?: string;
-  subTitle?: string;
-  formConfig: FormConfig;
-  tableConfig: TableConfig<T>;
   onEntitiesLoaded?: (entities: T[], entityType: string) => void;
-  defaultEntity?: T;
+  subTitle?: string;
+  tableConfig: TableConfig<T>;
 };
 
 type OwnProps<T extends BaseEntity> = GeneralEntityConfigType<T>;
@@ -127,17 +126,17 @@ type OwnProps<T extends BaseEntity> = GeneralEntityConfigType<T>;
 export type GeneralEntityRootProps<T extends BaseEntity> = OwnProps<T> & React.HTMLAttributes<HTMLDivElement>;
 
 export function GeneralEntityRoot<T extends BaseEntity>({
-  i18n,
+  importEnabled = true,
+  defaultEntity,
   endpoint,
   entityType,
   defaultSortField,
   entityName = 'Entität',
-  navigationTitle = 'Entitäten',
-  subTitle = '… mit denen man Dinge tun kann (aus Gründen bspw.)',
   formConfig,
-  tableConfig = {},
-  defaultEntity,
-  onEntitiesLoaded = () => { }
+  navigationTitle = 'Entitäten',
+  onEntitiesLoaded = () => { },
+  subTitle = '… mit denen man Dinge tun kann (aus Gründen bspw.)',
+  tableConfig = {}
 }: GeneralEntityRootProps<T>) {
 
   const location = useLocation();
@@ -824,7 +823,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
             </Button>
           </Link>
           {/* Upload only available for layer entities */}
-          {entityType === 'layer' && (
+          {entityType === 'layer' && importEnabled && (
             <Upload
               customRequest={onFileUploadAction}
               accept='image/tiff,application/zip'


### PR DESCRIPTION
By changing 

```
...
"importEnabled": false,
...
```

in `layers.json` config, the upload button will not be shown above layer entity table. 