### PR TITLE
fix: corrects sorting over multiple pages

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -111,6 +111,7 @@ export type GeneralEntityConfigType<T extends BaseEntity> = {
   i18n: FormTranslations;
   endpoint: string;
   entityType: string;
+  defaultSortField?: string;
   entityName?: string;
   navigationTitle?: string;
   subTitle?: string;
@@ -128,6 +129,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   i18n,
   endpoint,
   entityType,
+  defaultSortField,
   entityName = 'Entität',
   navigationTitle = 'Entitäten',
   subTitle = '… mit denen man Dinge tun kann (aus Gründen bspw.)',
@@ -170,10 +172,10 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   } = useTranslation();
 
   useEffect(() => {
-    setPageCurrent(1);
+    setSortField(defaultSortField? defaultSortField : undefined);
     setSortOrder('ascend');
-    setSortField(undefined);
-  }, [entityType]);
+    setPageCurrent(1);
+  }, [entityType, defaultSortField]);
 
   /**
    * Validate form fields

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -124,6 +124,7 @@ export const Portal: React.FC<PortalProps> = () => {
                   path={`${entityConfig?.entityType}/*`}
                   element={
                     <GeneralEntityRoot
+                      key={entityConfig.entityType}
                       {...entityConfig}
                       onEntitiesLoaded={onEntitiesLoaded}
                     />


### PR DESCRIPTION
This PR adjusts the sorting gover multiple pages by introducing a defaultSortField, which can be set in modelconfigs in shogun-docker. 
Every time the entity (or the defaultSortField) changes the sort field is set, when it is present in the config. 
A key had to be added to the GeneralEntityRoot in Portal.tsx to differentiate between the entities (and their defaultSortFields).