### PR TITLE
Introduces `ImageFileForm`

### DIFF
--- a/src/Component/ImageFile/ImageFileForm/ImageFileForm.less
+++ b/src/Component/ImageFile/ImageFileForm/ImageFileForm.less
@@ -1,0 +1,17 @@
+.image-file-form {
+
+  .ant-form-item-label > label {
+    white-space: pre-wrap;
+
+    &::after {
+      content: ' ';
+    }
+  }
+
+  .image-preview {
+    img {
+      border: 1px solid #d9d9d9;
+    }
+  }
+
+}

--- a/src/Component/ImageFile/ImageFileForm/ImageFileForm.tsx
+++ b/src/Component/ImageFile/ImageFileForm/ImageFileForm.tsx
@@ -1,0 +1,167 @@
+import './ImageFileForm.less';
+
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Form, PageHeader, Spin, Switch } from 'antd';
+import { SwitchChangeEventHandler } from 'antd/lib/switch';
+import _isNil from 'lodash/isNil';
+import { useTranslation } from 'react-i18next';
+import {
+  matchPath,
+  useLocation
+} from 'react-router-dom';
+import config from 'shogunApplicationConfig';
+
+import ImageFile from '@terrestris/shogun-util/dist/model/ImageFile';
+import { getBearerTokenHeader } from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
+
+import useSHOGunAPIClient from '../../../Hooks/useSHOGunAPIClient';
+
+interface OwnProps { }
+
+type ImageFileRootProps = OwnProps;
+
+export const ImageFileForm: React.FC<ImageFileRootProps> = () => {
+
+  const [fileBlob, setFileBlob] = useState<Blob>();
+  const [file, setFile] = useState<ImageFile>();
+  const [isPublic, setPublic] = useState<boolean>(false);
+
+  const location = useLocation();
+  const client = useSHOGunAPIClient();
+  const match = matchPath({
+    path: `${config.appPrefix}/portal/imagefile/:id`
+  }, location.pathname);
+  const imageFileId = match?.params?.id;
+
+  const {
+    t
+  } = useTranslation();
+
+  const onPublicChange: SwitchChangeEventHandler = useCallback(async (checked) => {
+    if (!client || _isNil(imageFileId)) {
+      setFileBlob(undefined);
+      return;
+    }
+    const response = await fetch(`/imagefiles/${imageFileId}/permissions/public`, {
+      method: checked ? 'POST' : 'DELETE',
+      headers: {
+        ...getBearerTokenHeader(client.getKeycloak())
+      }
+    });
+    if (response.ok) {
+      setPublic(checked);
+    }
+  }, [imageFileId, client]);
+
+  useEffect(() => {
+    if (!file) {
+      return;
+    }
+
+    const fetchImageBlob = async () => {
+      if (!client || _isNil(file.fileUuid)) {
+        return;
+      }
+      const response = await client.imagefile().findOne(file.fileUuid);
+      setFileBlob(response);
+    };
+
+    fetchImageBlob();
+  }, [file, client]);
+
+  useEffect(() => {
+    if (!client || _isNil(imageFileId)) {
+      setFileBlob(undefined);
+      return;
+    }
+
+    const fetchImageData = async () => {
+      const result = await client.graphql().sendQuery<ImageFile>({
+        query: `query($id: Int) {
+          imageFileById(id: $id) {
+            active
+            fileType
+            id
+            created
+            modified
+            fileUuid
+            fileName
+            width
+            height
+          }
+        }`,
+        variables: {
+          id: imageFileId
+        }
+      });
+      setFile(result.imageFileById);
+    };
+
+    const fetchPublicState = async () => {
+      const response = await fetch(`/imagefiles/${imageFileId}/permissions/public`, {
+        headers: {
+          ...getBearerTokenHeader(client.getKeycloak())
+        }
+      });
+      const data = await response.json();
+      setPublic(data.public);
+    };
+
+    fetchImageData();
+    fetchPublicState();
+  }, [imageFileId, client]);
+
+  return (
+    <>
+      <PageHeader
+        title={t('ImageFileForm.title')}
+      />
+      <Spin
+        spinning={false}
+      >
+        <Form
+          className="image-file-form"
+          labelCol={{ span: 5 }}
+          wrapperCol={{ span: 20 }}
+        >
+          <Form.Item
+            label={t('ImageFileForm.name')}
+          >
+            {file?.fileName}
+          </Form.Item>
+          <Form.Item
+            label={t('ImageFileForm.uuid')}
+          >
+            {
+              isPublic
+                ? <a target="_blank" href={`/imagefiles/${file?.fileUuid}`}>{file?.fileUuid}</a>
+                : file?.fileUuid
+            }
+          </Form.Item>
+          <Form.Item
+            label={t('ImageFileForm.public')}
+          >
+            <Switch
+              key="public"
+              checked={isPublic}
+              onChange={onPublicChange}
+            />
+          </Form.Item>
+          <Form.Item
+            label={t('ImageFileForm.preview')}
+          >
+            {
+              fileBlob &&
+              <div className="image-preview">
+                <img src={URL.createObjectURL(fileBlob)} alt="preview" />
+              </div>
+            }
+          </Form.Item>
+        </Form>
+      </Spin>
+    </>
+  );
+};
+
+export default ImageFileForm;

--- a/src/Component/ImageFile/ImageFileForm/ImageForm.spec.tsx
+++ b/src/Component/ImageFile/ImageFileForm/ImageForm.spec.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import { MemoryRouter } from 'react-router-dom';
+
+import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
+import { fetchSpy, successResponse } from '@terrestris/shogun-util/dist/spec/fetchSpy';
+
+import { SHOGunAPIClientProvider } from '../../../Context/SHOGunAPIClientContext';
+
+import { ImageFileForm } from './ImageFileForm';
+
+describe('<ImageFileForm />', () => {
+
+  let client: SHOGunAPIClient;
+  let wrapper: React.FC;
+
+  let fetchMock= fetchSpy(successResponse({}));
+
+  beforeEach(() => {
+    fetchMock = fetchSpy(successResponse({
+      public: true
+    }));
+    client = new SHOGunAPIClient();
+    const sendQuery = jest.fn().mockReturnValue({
+      imageFileById: {}
+    });
+    client.graphql = jest.fn().mockImplementation(() => ({
+      sendQuery
+    }));
+    wrapper = ({children}: any) => {
+      return (
+        <SHOGunAPIClientProvider client={client}>
+          <MemoryRouter initialEntries={['/undefined/portal/imagefile/119']}>
+            {children}
+          </MemoryRouter>
+        </SHOGunAPIClientProvider>
+      );
+    };
+  });
+
+  afterEach(() => {
+    if (fetchMock) {
+      fetchMock.mockReset();
+      fetchMock.mockRestore();
+    }
+  });
+
+  it('is defined', () => {
+    expect(ImageFileForm).not.toBeUndefined();
+  });
+
+  it('renders the form correctly', () => {
+    render(<ImageFileForm />, { wrapper });
+    expect(screen.getByText('ImageFileForm.title')).toBeInTheDocument();
+    expect(screen.getByText('ImageFileForm.name')).toBeInTheDocument();
+    expect(screen.getByText('ImageFileForm.uuid')).toBeInTheDocument();
+    expect(screen.getByText('ImageFileForm.public')).toBeInTheDocument();
+    expect(screen.getByText('ImageFileForm.preview')).toBeInTheDocument();
+  });
+
+  it('`isPublic` state is fetched initially', () => {
+    render(<ImageFileForm />, { wrapper });
+    expect(fetchMock).toHaveBeenCalledWith('/imagefiles/119/permissions/public', {
+      headers: {}
+    });
+  });
+
+});

--- a/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.less
+++ b/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.less
@@ -23,12 +23,6 @@
         padding: 0 0 10px 0;
       }
     }
-
-    &.right-container {
-      grid-area: right;
-      border-left: solid 2px @border-color-base;
-      padding: 0 24px 0 10px;
-    }
   }
 
 }

--- a/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.tsx
+++ b/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.tsx
@@ -1,16 +1,19 @@
 import './ImageFileRoot.less';
 
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import { Button, notification, PageHeader, Upload } from 'antd';
 import _isNil from 'lodash/isNil';
 import { useTranslation } from 'react-i18next';
-import {matchPath,
+import {
+  matchPath,
   useLocation,
-  useNavigate} from 'react-router-dom';
+  useNavigate
+} from 'react-router-dom';
 import config from 'shogunApplicationConfig';
 
 import useSHOGunAPIClient from '../../../Hooks/useSHOGunAPIClient';
+import ImageFileForm from '../ImageFileForm/ImageFileForm';
 import ImageFileTable from '../ImageFileTable/ImageFileTable';
 
 interface OwnProps { }
@@ -19,34 +22,18 @@ type ImageFileRootProps = OwnProps;
 
 export const ImageFileRoot: React.FC<ImageFileRootProps> = () => {
 
-  const [fileBlob, setFileBlob] = useState<Blob>();
-
   const navigate = useNavigate();
+
   const location = useLocation();
   const client = useSHOGunAPIClient();
   const match = matchPath({
-    path: `${config.appPrefix}/portal/imagefile/:uuid`
+    path: `${config.appPrefix}/portal/imagefile/:id`
   }, location.pathname);
-  const imageFileUuid = match?.params?.uuid;
+  const imageFileId = match?.params?.id;
 
   const {
     t
   } = useTranslation();
-
-  useEffect(() => {
-    if (!imageFileUuid) {
-      setFileBlob(undefined);
-      return;
-    }
-
-    const fetchImage = async () => {
-      const file = await client?.imagefile().findOne(imageFileUuid);
-
-      setFileBlob(file);
-    };
-
-    fetchImage();
-  }, [imageFileUuid, client]);
 
   return (
     <div className="imagefile-root">
@@ -64,6 +51,7 @@ export const ImageFileRoot: React.FC<ImageFileRootProps> = () => {
             showUploadList={false}
             customRequest={async (options) => {
               const file = options.file;
+
               if (!(file instanceof File)) {
                 return;
               }
@@ -75,7 +63,7 @@ export const ImageFileRoot: React.FC<ImageFileRootProps> = () => {
                     message: t('ImageFileRoot.success'),
                     description: t('ImageFileRoot.uploadSuccess', { entityName: file.name })
                   });
-                  navigate(`${config.appPrefix}/portal/imagefile/${uploadedFile.fileUuid}`);
+                  navigate(`${config.appPrefix}/portal/imagefile/${uploadedFile.id}`);
                 }
               } catch (error) {
                 notification.error({
@@ -92,12 +80,11 @@ export const ImageFileRoot: React.FC<ImageFileRootProps> = () => {
         </div>
         <ImageFileTable />
       </div>
-      {
-        fileBlob &&
-        <div className="right-container">
-          <img src={URL.createObjectURL(fileBlob)} />
-        </div>
-      }
+      <div className="right-container">
+        {
+          !_isNil(imageFileId) && (<ImageFileForm />)
+        }
+      </div>
     </div>
   );
 };

--- a/src/Component/ImageFile/ImageFileTable/ImageFileTable.tsx
+++ b/src/Component/ImageFile/ImageFileTable/ImageFileTable.tsx
@@ -54,7 +54,6 @@ export const ImageFileTable: React.FC<ImageFileTableProps> = ({
     key: 'fileUuid',
     dataIndex: 'fileUuid',
     sorter: TableUtil.getSorter('fileUuid'),
-    editable: true,
     ...TableUtil.getColumnSearchProps('fileUuid')
   }, {
     title: 'Name',
@@ -62,7 +61,6 @@ export const ImageFileTable: React.FC<ImageFileTableProps> = ({
     dataIndex: 'fileName',
     sorter: TableUtil.getSorter('fileName'),
     defaultSortOrder: 'ascend',
-    editable: true,
     ...TableUtil.getColumnSearchProps('fileName')
   }, {
     title: 'Created',
@@ -70,13 +68,12 @@ export const ImageFileTable: React.FC<ImageFileTableProps> = ({
     dataIndex: 'created',
     sorter: TableUtil.getSorter('created'),
     defaultSortOrder: 'descend',
-    editable: true,
     render: (val: string) => new Date(val).toLocaleString(i18n.language),
     ...TableUtil.getColumnSearchProps('created')
   }];
 
   const onRowClick = (imageFile: ImageFile) => {
-    navigate(`${config.appPrefix}/portal/imagefile/${imageFile.fileUuid}`);
+    navigate(`${config.appPrefix}/portal/imagefile/${imageFile.id}`);
   };
 
   const name = {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -100,6 +100,13 @@ export default {
         uploadSuccess: 'Die Datei {{entityName}} wurde erfolgreich hochgeladen',
         uploadFailure: 'Die Datei {{entityName}} konnte nicht hochgeladen werden'
       },
+      ImageFileForm: {
+        title: 'Bilddatei',
+        name: 'Dateiname',
+        uuid: 'UUID',
+        public: 'Öffentlich',
+        preview: 'Vorschau'
+      },
       Logs: {
         logs: 'Logs',
         logsInfo: '… die die Welt erklären',
@@ -311,6 +318,13 @@ export default {
         failure: 'Error during upload',
         uploadSuccess: 'The {{entityName}} file was successfully uploaded',
         uploadFailure: 'The file {{entityName}} could not be uploaded'
+      },
+      ImageFileForm: {
+        title: 'Image',
+        name: 'Filename',
+        uuid: 'UUID',
+        public: 'Public',
+        preview: 'Preview'
       },
       Logs: {
         metric: 'Metrics',

--- a/test/setup.js
+++ b/test/setup.js
@@ -10,3 +10,19 @@ Object.defineProperty(global, 'ResizeObserver', {
     disconnect: jest.fn()
   }))
 });
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
+
+global.fetch = jest.fn();


### PR DESCRIPTION
This introduces the `ImageFileForm`. It replaces the previously existing preview and adds some more information, aswell as the public switch. As the public state of an entity is handled via its id the routing was modified. See breaking change info below.

![shogun-admin_image-file-form](https://github.com/terrestris/shogun-admin/assets/1849416/caf5ccbc-5cf5-4e1d-a926-bb88a5d3f95f)

:exclamation: BREAKING CHANGE: The route to an specific ImageFile now needs the image-id instead of the image-uuid