### PR TITLE
Always fetch entity on save/update

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -343,6 +343,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
     try {
       const updatedEntity: T = await entityController?.saveOrUpdate() as T;
       await fetchEntities();
+      await fetchEntity(updatedEntity.id!);
       navigate(`${config.appPrefix}/portal/${entityType}/${updatedEntity.id}`);
       notification.success({
         message: t('GeneralEntityRoot.saveSuccess', {


### PR DESCRIPTION
This ensures the feature is refetched after saving.
This is need as the navigate method does not trigger a fetch when updating as the route param does not update but fetching a call of `fetchEntity` is needed to get the correct state of `isPublic`.