### PR TITLE
feat: adds a save warning when entity is changed

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -293,7 +293,8 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   useEffect(() => {
     if (formIsDirty) {
       // only set if it changes from false to true, but not when it changes back
-      setIsPreviousFormDirty(true);    }
+      setIsPreviousFormDirty(true);
+    }
   }, [formIsDirty]);
 
   /**

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -162,12 +162,11 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   const [sortField, setSortField] = useState<string>();
   const [sortOrder, setSortOrder] = useState<SortOrder>();
   const [isFiltered, setFiltered] = useState<boolean>(false);
-
+  const [isPreviousFormDirty, setIsPreviousFormDirty] = useState<boolean>(false);
   const [modal, contextHolder] = Modal.useModal();
   const [form] = Form.useForm();
 
   const client = useSHOGunAPIClient();
-  let isPreviousFormDirty = useRef(formIsDirty);
   const {
     t
   } = useTranslation();
@@ -258,7 +257,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
    */
   useEffect(() => {
     if (id && id.toString() !== 'create' && id !== editEntity?.id) {
-      if (isPreviousFormDirty.current) {
+      if (isPreviousFormDirty) {
         modal.confirm({
           title: t('GeneralEntityRoot.reminderModal.title'),
           content: t('GeneralEntityRoot.reminderModal.description'),
@@ -277,22 +276,25 @@ export function GeneralEntityRoot<T extends BaseEntity>({
             });
           }
         });
-        isPreviousFormDirty.current = formIsDirty;
       }
       else {
         fetchEntity(parseInt(id.toString(), 10));
       }
+      // here we either saved or discarded the changes, so we don't need the value anymore
+      setIsPreviousFormDirty(false);
     }
     if (id && id.toString() === 'create' && editEntity === undefined) {
       const e: T = entityController?.createEntity();
       setEditEntity(e);
       form.setFieldsValue(entityController?.getEntity());
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, fetchEntity, formIsDirty, editEntity, entityController, form, modal]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, fetchEntity, editEntity, entityController, form, modal]);
 
   useEffect(() => {
-    isPreviousFormDirty.current = formIsDirty;
+    if (formIsDirty) {
+      // only set if it changes from false to true, but not when it changes back
+      setIsPreviousFormDirty(true);    }
   }, [formIsDirty]);
 
   /**

--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -4,7 +4,6 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState
 } from 'react';
 

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -63,7 +63,14 @@ export default {
           },
           button: '{{entity}} hochladen'
         },
+        reminderModal: {
+          title: 'Änderungen speichern?',
+          description: 'Die Änderungen wurden noch nicht gespeichert, möchten Sie speichern?',
+          accept: 'Speichern',
+          decline: 'Verwerfen'
+        },
         saveSuccess: '{{entity}} erfolgreich gespeichert',
+        saveWarning: '{{entity}} wurde nicht gespeichert!',
         saveFail: 'Konnte {{entity}} nicht speichern'
       },
       GeneralEntityTable: {
@@ -281,7 +288,14 @@ export default {
           },
           button: 'Upload {{entity}}'
         },
+        reminderModal: {
+          title: 'Save changes?',
+          description: 'The changes made were not saved yet, do you want to save them?',
+          accept: 'Save',
+          decline: 'Discard'
+        },
         saveSuccess: '{{entity}} successfully saved',
+        saveWarning: '{{entity}} was not saved!',
         saveFail: 'Could not save {{entity}}'
       },
       GeneralEntityTable: {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -70,7 +70,7 @@ export default {
           decline: 'Verwerfen'
         },
         saveSuccess: '{{entity}} erfolgreich gespeichert',
-        saveWarning: '{{entity}} wurde nicht gespeichert!',
+        saveWarning: '{{entity}} wurde nicht gespeichert',
         saveFail: 'Konnte {{entity}} nicht speichern'
       },
       GeneralEntityTable: {
@@ -290,12 +290,12 @@ export default {
         },
         reminderModal: {
           title: 'Save changes?',
-          description: 'The changes made were not saved yet, do you want to save them?',
+          description: 'The changes have not yet been saved, do you want to save?',
           accept: 'Save',
           decline: 'Discard'
         },
         saveSuccess: '{{entity}} successfully saved',
-        saveWarning: '{{entity}} was not saved!',
+        saveWarning: '{{entity}} has not been saved',
         saveFail: 'Could not save {{entity}}'
       },
       GeneralEntityTable: {


### PR DESCRIPTION
This PR adds a new modal to warn the user that their changes were not saved in case they switch entity without saving there changes. The modal look like this:  
![image](https://github.com/terrestris/shogun-admin/assets/109729343/5dadc871-6cd7-40d1-9a57-53be07b3c141)
