### PR TITLE
fix: center the logo while loading

### DIFF
--- a/src/App.less
+++ b/src/App.less
@@ -22,4 +22,5 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  transform: translateY(125%);
 }

--- a/src/App.less
+++ b/src/App.less
@@ -19,8 +19,7 @@
 .result-spin {
   height: 100%;
   width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  transform: translateY(125%);
+  display:block;
+  position: absolute;
+  top: 50%;
 }

--- a/src/App.less
+++ b/src/App.less
@@ -19,7 +19,7 @@
 .result-spin {
   height: 100%;
   width: 100%;
-  display:block;
+  display: block;
   position: absolute;
   top: 50%;
 }


### PR DESCRIPTION
This PR centers the logo while loading the shogun-admin as described in [#21849](https://redmine.intranet.terrestris.de/issues/21849?include=journals&journals=all)

Picture of the issue:
![LoadingBefore](https://github.com/terrestris/shogun-admin/assets/161820732/4cd9f21a-c262-49aa-87ef-a79948bc0b06)

After fixing:
![LoadingAfter](https://github.com/terrestris/shogun-admin/assets/161820732/c7e44d7b-dd6b-4d09-af7f-d8d659684a96)

Please review :)
