### PR TITLE
Sonar-Scan

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   sonarqube:
+    if: ${{ github.actor != 'dependabot[bot]' }}
     name: SonarQube Trigger
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION


This MR ensures that merging from dependabot does not send a report to sonarqube
