### PR TITLE
Update release pipelines

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,10 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - main
+      - next
 
 env:
   DOCKER_REGISTRY: docker-public.terrestris.de/terrestris

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,10 @@
 {
   "branches": [
-    "main"
+    "main",
+    {
+      "name": "next",
+      "prerelease": true
+    }
   ],
   "plugins": [
     [
@@ -40,12 +44,7 @@
         }
       }
     ],
-    [
-      "@semantic-release/npm",
-      {
-        "npmPublish": false
-      }
-    ],
+    "@semantic-release/npm",
     "@semantic-release/changelog",
     [
       "@semantic-release/git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "16.0.0",
   "description": "The admin UI for the SHOGun Web-mapping backend.",
   "main": "index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc && vite build",
     "clean:dist": "rimraf ./dist/*",


### PR DESCRIPTION
This will update the release pipelines as follows:

- publishing to npm will be activated so that you can use the `shogun-admin` as a dependency
- when pushing to the branch `next` and automated prerelease will be triggered `x.x.x-next.x`
- automated releases for the main branch have been disabled and have to be triggered manually