### PR TITLE
ci: update sonarqube-scanner

### DIFF
--- a/.github/workflows/on-push-main.yml
+++ b/.github/workflows/on-push-main.yml
@@ -44,7 +44,9 @@ jobs:
           echo "sonar.projectVersion=$(node -pe "require('./package.json').version")" >> ./sonar-project.properties
 
       - name: SonarQube Scan 🔬
-        uses: kitabisa/sonarqube-action@v1.2.1
+        uses: SonarSource/sonarqube-scan-action@v2.3.0
         with:
-          host: ${{ secrets.SONARQUBE_HOST }}
-          login: ${{ secrets.SONARQUBE_TOKEN }}
+          projectBaseDir: .
+        env:
+          SONAR_TOKEN: ${{ secrets.SONARQUBE_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONARQUBE_HOST }}


### PR DESCRIPTION
This updates the SonarQube scan action to use the SonarSource/sonarqube-scan-action@v2.3.0
This is necessary, because the previous SonarQube scanner causes an error with SonarQube version 10.6.
