### PR TITLE
Pass image ID as number to GraphQL endpoint

### DIFF
--- a/src/Component/ImageFile/ImageFileForm/ImageFileForm.tsx
+++ b/src/Component/ImageFile/ImageFileForm/ImageFileForm.tsx
@@ -93,7 +93,7 @@ export const ImageFileForm: React.FC<ImageFileRootProps> = () => {
           }
         }`,
         variables: {
-          id: imageFileId
+          id: parseInt(imageFileId, 10)
         }
       });
       setFile(result.imageFileById);


### PR DESCRIPTION
This is needed since the endpoint doesn't accept a string as input here.

Please review @terrestris/devs.