### PR TITLE
Introduce buttons to create users, groups and roles from the respective provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@monaco-editor/react": "4.6.0",
         "@terrestris/base-util": "3.0.0",
         "@terrestris/ol-util": "21.0.0",
-        "@terrestris/shogun-util": "9.1.1",
+        "@terrestris/shogun-util": "10.2.0",
         "@uiw/react-md-editor": "4.0.4",
         "antd": "5.21.5",
         "i18next": "23.16.2",
@@ -6209,14 +6209,14 @@
       }
     },
     "node_modules/@terrestris/shogun-util": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-9.1.1.tgz",
-      "integrity": "sha512-dpYQOf5IuaM7k1fZFLTdy3e4N4Rsk8lP5aCX0Vy5e2X7/7cwuXzbuFjBdjtUvZgq4rM/pYN5sTiMURzF31d/Wg==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/@terrestris/shogun-util/-/shogun-util-10.2.0.tgz",
+      "integrity": "sha512-dj+FmNMc7PBn5X1/159Cc3/aQ0Wb7cVUPoRQqLVMuF2uW+aEfC44QUUwFGsfkzv6MNjrbFiGKk9qwrbOps7Jzw==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@terrestris/base-util": "^2.0.0",
+        "@terrestris/base-util": "^3.0.0",
         "geojson": "^0.5.0",
-        "keycloak-js": "^26.0.1",
+        "keycloak-js": "^26.0.5",
         "lodash": "^4.17.21"
       },
       "engines": {
@@ -6228,23 +6228,11 @@
         "ol": ">=10"
       }
     },
-    "node_modules/@terrestris/shogun-util/node_modules/@terrestris/base-util": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@terrestris/base-util/-/base-util-2.0.0.tgz",
-      "integrity": "sha512-Pe4/n4toCQC898K4pLHSC4CFPPKOgFNOI7XyY9JnB3WCjl4NETakuOeHr259LFBsBt10PQIcXr94u5rxjzd4tg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@ungap/url-search-params": "^0.2.2",
-        "lodash": "^4.17.21",
-        "loglevel": "^1.8.0",
-        "query-string": "^9.0.0",
-        "url-parse": "^1.5.10",
-        "validator": "^13.11.0"
-      },
-      "engines": {
-        "node": ">=20",
-        "npm": ">=10"
-      }
+    "node_modules/@terrestris/shogun-util/node_modules/keycloak-js": {
+      "version": "26.0.5",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-26.0.5.tgz",
+      "integrity": "sha512-3biQ5e+yX8EkU3+2ZO+YbWl0emooXt1wyKgZdGCFW8gT0oKeQh/AK6R9a53ACWBzDVoTBI+0GbXP2jF1sFMznw==",
+      "license": "Apache-2.0"
     },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@monaco-editor/react": "4.6.0",
     "@terrestris/base-util": "3.0.0",
     "@terrestris/ol-util": "21.0.0",
-    "@terrestris/shogun-util": "9.1.1",
+    "@terrestris/shogun-util": "10.2.0",
     "@uiw/react-md-editor": "4.0.4",
     "antd": "5.21.5",
     "i18next-browser-languagedetector": "8.0.0",

--- a/src/Component/CreateAllGroupsButton/CreateAllGroupsButton.spec.tsx
+++ b/src/Component/CreateAllGroupsButton/CreateAllGroupsButton.spec.tsx
@@ -33,7 +33,7 @@ jest.mock('../../Hooks/useSHOGunAPIClient', () => {
   };
 });
 
-describe('<CreateAllUsersButton />', () => {
+describe('<CreateAllGroupsButton />', () => {
 
   afterEach(cleanup);
 

--- a/src/Component/CreateAllGroupsButton/CreateAllGroupsButton.spec.tsx
+++ b/src/Component/CreateAllGroupsButton/CreateAllGroupsButton.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react';
+
+import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
+
+import { CreateAllGroupsButton } from './CreateAllGroupsButton';
+import GroupService from '@terrestris/shogun-util/dist/service/GroupService';
+import Group from '@terrestris/shogun-util/dist/model/Group';
+
+import type { PartialOmit } from '../../test-util';
+
+const mockService: Partial<GroupService<Group>> = {
+  createAllFromProvider: jest.fn()
+};
+
+const mockSHOGunAPIClient: PartialOmit<SHOGunAPIClient, 'group'> = {
+  group: jest.fn().mockReturnValue(mockService)
+};
+
+jest.mock('../../Hooks/useSHOGunAPIClient', () => {
+  const originalModule = jest.requireActual('../../Hooks/useSHOGunAPIClient');
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: jest.fn(() => mockSHOGunAPIClient)
+  };
+});
+
+describe('<CreateAllUsersButton />', () => {
+
+  afterEach(cleanup);
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(
+      <CreateAllGroupsButton />);
+
+    expect(container).toBeVisible();
+  });
+
+  it('calls the appropriate service method', async () => {
+    render(<CreateAllGroupsButton />);
+
+    const buttonElement = screen.getByText('CreateAllGroupsButton.title');
+
+    fireEvent.click(buttonElement);
+
+    expect(mockSHOGunAPIClient.group().createAllFromProvider).toHaveBeenCalled();
+
+    await waitForElementToBeRemoved(() => screen.queryByLabelText('loading'));
+
+    expect(screen.getByText('CreateAllGroupsButton.success')).toBeVisible();
+  });
+});

--- a/src/Component/CreateAllGroupsButton/CreateAllGroupsButton.tsx
+++ b/src/Component/CreateAllGroupsButton/CreateAllGroupsButton.tsx
@@ -1,0 +1,81 @@
+import React, {
+  useState
+} from 'react';
+
+import {
+  UsergroupAddOutlined
+} from '@ant-design/icons';
+import {
+  Button,
+  message,
+  Tooltip
+} from 'antd';
+import { ButtonProps } from 'antd/lib/button';
+
+import { useTranslation } from 'react-i18next';
+
+import useSHOGunAPIClient from '../../Hooks/useSHOGunAPIClient';
+
+import Logger from '../../Logger';
+
+export type CreateAllGroupsButtonProps = Omit<ButtonProps, 'onClick' | 'loading'> & {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+};
+
+export const CreateAllGroupsButton: React.FC<CreateAllGroupsButtonProps> = ({
+  onSuccess,
+  onError,
+  ...passThroughProps
+}) => {
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const client = useSHOGunAPIClient();
+
+  const {
+    t
+  } = useTranslation();
+
+  const onCreateGroupsClick = async () => {
+    setIsLoading(true);
+
+    try {
+      await client?.group().createAllFromProvider();
+
+      messageApi.success(t('CreateAllGroupsButton.success'));
+
+      onSuccess?.();
+    } catch (error) {
+      messageApi.error(t('CreateAllGroupsButton.error'));
+
+      Logger.error('Error while creating the groups: ', error);
+
+      onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Tooltip
+        title={t('CreateAllGroupsButton.tooltip')}
+      >
+        <Button
+          onClick={onCreateGroupsClick}
+          loading={isLoading}
+          icon={<UsergroupAddOutlined />}
+          {...passThroughProps}
+        >
+          {t('CreateAllGroupsButton.title')}
+        </Button>
+      </Tooltip>
+    </>
+  );
+};
+
+export default CreateAllGroupsButton;

--- a/src/Component/CreateAllRolesButton/CreateAllRolesButton.spec.tsx
+++ b/src/Component/CreateAllRolesButton/CreateAllRolesButton.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react';
+
+import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
+
+import { CreateAllRolesButton } from './CreateAllRolesButton';
+import RoleService from '@terrestris/shogun-util/dist/service/RoleService';
+import Role from '@terrestris/shogun-util/dist/model/Role';
+
+import type { PartialOmit } from '../../test-util';
+
+const mockService: Partial<RoleService<Role>> = {
+  createAllFromProvider: jest.fn()
+};
+
+const mockSHOGunAPIClient: PartialOmit<SHOGunAPIClient, 'role'> = {
+  role: jest.fn().mockReturnValue(mockService)
+};
+
+jest.mock('../../Hooks/useSHOGunAPIClient', () => {
+  const originalModule = jest.requireActual('../../Hooks/useSHOGunAPIClient');
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: jest.fn(() => mockSHOGunAPIClient)
+  };
+});
+
+describe('<CreateAllRolesButton />', () => {
+
+  afterEach(cleanup);
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(
+      <CreateAllRolesButton />);
+
+    expect(container).toBeVisible();
+  });
+
+  it('calls the appropriate service method', async () => {
+    render(<CreateAllRolesButton />);
+
+    const buttonElement = screen.getByText('CreateAllRolesButton.title');
+
+    fireEvent.click(buttonElement);
+
+    expect(mockSHOGunAPIClient.role().createAllFromProvider).toHaveBeenCalled();
+
+    await waitForElementToBeRemoved(() => screen.queryByLabelText('loading'));
+
+    expect(screen.getByText('CreateAllRolesButton.success')).toBeVisible();
+  });
+});

--- a/src/Component/CreateAllRolesButton/CreateAllRolesButton.tsx
+++ b/src/Component/CreateAllRolesButton/CreateAllRolesButton.tsx
@@ -1,0 +1,81 @@
+import React, {
+  useState
+} from 'react';
+
+import {
+  TagOutlined
+} from '@ant-design/icons';
+import {
+  Button,
+  message,
+  Tooltip
+} from 'antd';
+import { ButtonProps } from 'antd/lib/button';
+
+import { useTranslation } from 'react-i18next';
+
+import useSHOGunAPIClient from '../../Hooks/useSHOGunAPIClient';
+
+import Logger from '../../Logger';
+
+export type CreateAllRolesButtonProps = Omit<ButtonProps, 'onClick' | 'loading'> & {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+};
+
+export const CreateAllRolesButton: React.FC<CreateAllRolesButtonProps> = ({
+  onSuccess,
+  onError,
+  ...passThroughProps
+}) => {
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const client = useSHOGunAPIClient();
+
+  const {
+    t
+  } = useTranslation();
+
+  const onCreateRolesClick = async () => {
+    setIsLoading(true);
+
+    try {
+      await client?.role().createAllFromProvider();
+
+      messageApi.success(t('CreateAllRolesButton.success'));
+
+      onSuccess?.();
+    } catch (error) {
+      messageApi.error(t('CreateAllRolesButton.error'));
+
+      Logger.error('Error while creating the roles: ', error);
+
+      onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Tooltip
+        title={t('CreateAllRolesButton.tooltip')}
+      >
+        <Button
+          onClick={onCreateRolesClick}
+          loading={isLoading}
+          icon={<TagOutlined />}
+          {...passThroughProps}
+        >
+          {t('CreateAllRolesButton.title')}
+        </Button>
+      </Tooltip>
+    </>
+  );
+};
+
+export default CreateAllRolesButton;

--- a/src/Component/CreateAllUsersButton/CreateAllUsersButton.spec.tsx
+++ b/src/Component/CreateAllUsersButton/CreateAllUsersButton.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitForElementToBeRemoved
+} from '@testing-library/react';
+
+import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
+
+import { CreateAllUsersButton } from './CreateAllUsersButton';
+import UserService from '@terrestris/shogun-util/dist/service/UserService';
+import User from '@terrestris/shogun-util/dist/model/User';
+
+import type { PartialOmit } from '../../test-util';
+
+const mockService: Partial<UserService<User>> = {
+  createAllFromProvider: jest.fn()
+};
+
+const mockSHOGunAPIClient: PartialOmit<SHOGunAPIClient, 'user'> = {
+  user: jest.fn().mockReturnValue(mockService)
+};
+
+jest.mock('../../Hooks/useSHOGunAPIClient', () => {
+  const originalModule = jest.requireActual('../../Hooks/useSHOGunAPIClient');
+  return {
+    __esModule: true,
+    ...originalModule,
+    default: jest.fn(() => mockSHOGunAPIClient)
+  };
+});
+
+describe('<CreateAllUsersButton />', () => {
+
+  afterEach(cleanup);
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(
+      <CreateAllUsersButton />);
+
+    expect(container).toBeVisible();
+  });
+
+  it('calls the appropriate service method', async () => {
+    render(<CreateAllUsersButton />);
+
+    const buttonElement = screen.getByText('CreateAllUsersButton.title');
+
+    fireEvent.click(buttonElement);
+
+    expect(mockSHOGunAPIClient.user().createAllFromProvider).toHaveBeenCalled();
+
+    await waitForElementToBeRemoved(() => screen.queryByLabelText('loading'));
+
+    expect(screen.getByText('CreateAllUsersButton.success')).toBeVisible();
+  });
+});

--- a/src/Component/CreateAllUsersButton/CreateAllUsersButton.tsx
+++ b/src/Component/CreateAllUsersButton/CreateAllUsersButton.tsx
@@ -1,0 +1,81 @@
+import React, {
+  useState
+} from 'react';
+
+import {
+  UserAddOutlined
+} from '@ant-design/icons';
+import {
+  Button,
+  message,
+  Tooltip
+} from 'antd';
+import { ButtonProps } from 'antd/lib/button';
+
+import { useTranslation } from 'react-i18next';
+
+import useSHOGunAPIClient from '../../Hooks/useSHOGunAPIClient';
+
+import Logger from '../../Logger';
+
+export type CreateAllUsersButtonProps = Omit<ButtonProps, 'onClick' | 'loading'> & {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+};
+
+export const CreateAllUsersButton: React.FC<CreateAllUsersButtonProps> = ({
+  onSuccess,
+  onError,
+  ...passThroughProps
+}) => {
+
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const [messageApi, contextHolder] = message.useMessage();
+
+  const client = useSHOGunAPIClient();
+
+  const {
+    t
+  } = useTranslation();
+
+  const onCreateUsersClick = async () => {
+    setIsLoading(true);
+
+    try {
+      await client?.user().createAllFromProvider();
+
+      messageApi.success(t('CreateAllUsersButton.success'));
+
+      onSuccess?.();
+    } catch (error) {
+      messageApi.success(t('CreateAllUsersButton.error'));
+
+      Logger.error('Error while creating the users: ', error);
+
+      onError?.(error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <>
+      {contextHolder}
+      <Tooltip
+        title={t('CreateAllUsersButton.tooltip')}
+      >
+        <Button
+          onClick={onCreateUsersClick}
+          loading={isLoading}
+          icon={<UserAddOutlined />}
+          {...passThroughProps}
+        >
+          {t('CreateAllUsersButton.title')}
+        </Button>
+      </Tooltip>
+    </>
+  );
+};
+
+export default CreateAllUsersButton;

--- a/src/Component/FormField/Permission/InstancePermissionGrid/InstancePermissionGrid.spec.tsx
+++ b/src/Component/FormField/Permission/InstancePermissionGrid/InstancePermissionGrid.spec.tsx
@@ -15,9 +15,6 @@ import { t } from 'i18next';
 
 import InstancePermission from '@terrestris/shogun-util/dist/model/security/InstancePermission';
 import User, { KeycloakUserRepresentation } from '@terrestris/shogun-util/dist/model/User';
-import SHOGunAPIClient from '@terrestris/shogun-util/dist/service/SHOGunAPIClient';
-
-import useSHOGunAPIClient from '../../../../Hooks/useSHOGunAPIClient';
 
 import InstancePermissionGrid, { DataType, EntityType } from './InstancePermissionGrid';
 

--- a/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, {
+  useContext
+} from 'react';
 
 import { PageHeader } from '@ant-design/pro-components';
 
@@ -12,14 +14,15 @@ import {
   Statistic,
   Switch
 } from 'antd';
-import './GeneralEntityForm.less';
 
 import {
   FormInstance,
   FormItemProps,
   FormProps
 } from 'antd/lib/form';
+
 import Logger from 'js-logger';
+
 import _cloneDeep from 'lodash/cloneDeep';
 
 import TranslationUtil from '../../../Util/TranslationUtil';
@@ -32,8 +35,13 @@ import RolePermissionGrid from '../../FormField/Permission/RolePermissionGrid/Ro
 import UserPermissionGrid from '../../FormField/Permission/UserPermissionGrid/UserPermissionGrid';
 import YesOrNoField from '../../FormField/YesOrNoField/YesOrNoField';
 import LayerTypeSelect from '../../Layer/LayerTypeSelect/LayerTypeSelect';
+import GeneralEntityRootContext, {
+  ContextValue
+} from '../../../Context/GeneralEntityRootContext';
 
 const { TextArea } = Input;
+
+import './GeneralEntityForm.less';
 
 export type FieldConfig = {
   component?: string;
@@ -69,8 +77,6 @@ interface OwnProps {
   loading?: boolean;
   i18n: FormTranslations;
   entityId?: number;
-  entityName: string;
-  entityType: string;
   formConfig: FormConfig;
   formProps?: Partial<FormProps>;
   form: FormInstance;
@@ -84,12 +90,12 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
   loading = false,
   i18n,
   entityId,
-  entityName,
-  entityType,
   formProps,
   form,
   formConfig
 }) => {
+
+  const generalEntityRootContext = useContext<ContextValue<any> | undefined>(GeneralEntityRootContext);
 
   /**
    * Create read-only components for certain form items
@@ -173,7 +179,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
       case 'JSONEditor':
         return (
           <JSONEditor
-            entityType={entityType}
+            entityType={generalEntityRootContext?.entityType || ''}
             dataField={fieldCfg.dataField}
             {
               ...fieldCfg?.fieldProps
@@ -199,7 +205,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
         return (
           <UserPermissionGrid
             entityId={form.getFieldValue('id')}
-            entityType={entityType.toLowerCase() as EntityType}
+            entityType={generalEntityRootContext?.entityType?.toLowerCase() as EntityType}
             {...fieldCfg?.fieldProps}
           />
         );
@@ -211,7 +217,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
         return (
           <GroupPermissionGrid
             entityId={form.getFieldValue('id')}
-            entityType={entityType.toLowerCase() as EntityType}
+            entityType={generalEntityRootContext?.entityType?.toLowerCase() as EntityType}
             {...fieldCfg?.fieldProps}
           />
         );
@@ -223,7 +229,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
         return (
           <RolePermissionGrid
             entityId={form.getFieldValue('id')}
-            entityType={entityType.toLowerCase() as EntityType}
+            entityType={generalEntityRootContext?.entityType?.toLowerCase() as EntityType}
             {...fieldCfg?.fieldProps}
           />
         );
@@ -308,7 +314,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
 
     return (
       <Form.Item
-        key={`${entityType}-${form.getFieldValue('id')}-${dataField || component?.toLocaleLowerCase()}`}
+        key={`${generalEntityRootContext?.entityType}-${form.getFieldValue('id')}-${dataField || component?.toLocaleLowerCase()}`}
         name={dataField}
         className={`cls-${dataField}`}
         normalize={copyFieldCfg.component ? getNormalizeFn() : undefined}
@@ -323,7 +329,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
 
   const initialValues = {};
 
-  const title = TranslationUtil.getTranslationFromConfig(entityName, i18n);
+  const title = TranslationUtil.getTranslationFromConfig(generalEntityRootContext?.entityName, i18n);
 
   return (
     <>

--- a/src/Component/GeneralEntity/Slots/ToolbarCreateAllGroupsButton/ToolbarCreateAllGroupsButton.tsx
+++ b/src/Component/GeneralEntity/Slots/ToolbarCreateAllGroupsButton/ToolbarCreateAllGroupsButton.tsx
@@ -1,0 +1,29 @@
+import {
+  useContext
+} from 'react';
+
+import Group from '@terrestris/shogun-util/dist/model/Group';
+
+import CreateAllGroupsButton, {
+  CreateAllGroupsButtonProps
+} from '../../../CreateAllGroupsButton/CreateAllGroupsButton';
+
+import GeneralEntityRootContext, {
+  ContextValue
+} from '../../../../Context/GeneralEntityRootContext';
+
+export const ToolbarCreateAllGroupsButton: React.FC<CreateAllGroupsButtonProps> = () => {
+  const generalEntityRootContext = useContext<ContextValue<Group> | undefined>(GeneralEntityRootContext);
+
+  const onSuccess = () => {
+    generalEntityRootContext?.fetchEntities?.();
+  };
+
+  return (
+    <CreateAllGroupsButton
+      onSuccess={onSuccess}
+    />
+  );
+};
+
+export default ToolbarCreateAllGroupsButton;

--- a/src/Component/GeneralEntity/Slots/ToolbarCreateAllRolesButton/ToolbarCreateAllRolesButton.tsx
+++ b/src/Component/GeneralEntity/Slots/ToolbarCreateAllRolesButton/ToolbarCreateAllRolesButton.tsx
@@ -1,0 +1,29 @@
+import {
+  useContext
+} from 'react';
+
+import Role from '@terrestris/shogun-util/dist/model/Role';
+
+import CreateAllRolesButton, {
+  CreateAllRolesButtonProps
+} from '../../../CreateAllRolesButton/CreateAllRolesButton';
+
+import GeneralEntityRootContext, {
+  ContextValue
+} from '../../../../Context/GeneralEntityRootContext';
+
+export const ToolbarCreateAllRolesButton: React.FC<CreateAllRolesButtonProps> = () => {
+  const generalEntityRootContext = useContext<ContextValue<Role> | undefined>(GeneralEntityRootContext);
+
+  const onSuccess = () => {
+    generalEntityRootContext?.fetchEntities?.();
+  };
+
+  return (
+    <CreateAllRolesButton
+      onSuccess={onSuccess}
+    />
+  );
+};
+
+export default ToolbarCreateAllRolesButton;

--- a/src/Component/GeneralEntity/Slots/ToolbarCreateAllUsersButton/ToolbarCreateAllUsersButton.tsx
+++ b/src/Component/GeneralEntity/Slots/ToolbarCreateAllUsersButton/ToolbarCreateAllUsersButton.tsx
@@ -1,0 +1,29 @@
+import {
+  useContext
+} from 'react';
+
+import User from '@terrestris/shogun-util/dist/model/User';
+
+import CreateAllUsersButton, {
+  CreateAllUsersButtonProps
+} from '../../../CreateAllUsersButton/CreateAllUsersButton';
+
+import GeneralEntityRootContext, {
+  ContextValue
+} from '../../../../Context/GeneralEntityRootContext';
+
+export const ToolbarCreateAllUsersButton: React.FC<CreateAllUsersButtonProps> = () => {
+  const generalEntityRootContext = useContext<ContextValue<User> | undefined>(GeneralEntityRootContext);
+
+  const onSuccess = () => {
+    generalEntityRootContext?.fetchEntities?.();
+  };
+
+  return (
+    <CreateAllUsersButton
+      onSuccess={onSuccess}
+    />
+  );
+};
+
+export default ToolbarCreateAllUsersButton;

--- a/src/Component/GeneralEntity/Slots/ToolbarUploadLayerButton/ToolbarUploadLayerButton.tsx
+++ b/src/Component/GeneralEntity/Slots/ToolbarUploadLayerButton/ToolbarUploadLayerButton.tsx
@@ -1,0 +1,25 @@
+import {
+  useContext
+} from 'react';
+
+import UploadLayerButton, {
+  UploadLayerButtonProps
+} from '../../../UploadLayerButton/UploadLayerButton';
+
+import GeneralEntityRootContext from '../../../../Context/GeneralEntityRootContext';
+
+export const ToolbarUploadLayerButton: React.FC<UploadLayerButtonProps> = () => {
+  const generalEntityRootContext = useContext(GeneralEntityRootContext);
+
+  const onSuccess = () => {
+    generalEntityRootContext?.fetchEntities?.();
+  };
+
+  return (
+    <UploadLayerButton
+      onSuccess={onSuccess}
+    />
+  );
+};
+
+export default ToolbarUploadLayerButton;

--- a/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.spec.tsx
+++ b/src/Component/ImageFile/ImageFileRoot/ImageFileRoot.spec.tsx
@@ -76,7 +76,6 @@ describe('<ImageFileRoot />', () => {
 
   it('should handle file upload', async () => {
     const {
-      getByText,
       container
     } = render(
       <RecoilRoot>

--- a/src/Component/Menu/Navigation/Navigation.spec.tsx
+++ b/src/Component/Menu/Navigation/Navigation.spec.tsx
@@ -7,7 +7,11 @@ import {
   waitFor,
 } from '@testing-library/react';
 
-import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
+import {
+  MemoryRouter,
+  useLocation,
+  useNavigate
+} from 'react-router-dom';
 
 import { Navigation } from './Navigation';
 
@@ -81,8 +85,6 @@ describe('<Navigation />', () => {
       expect(screen.getByText('Global')).toBeInTheDocument();
       expect(screen.getByText('Logging levels')).toBeInTheDocument();
     });
-
-
   });
 
   it('opens submenu when an item is selected', async () => {
@@ -132,4 +134,88 @@ describe('<Navigation />', () => {
     expect(container.querySelector('.ant-menu-inline-collapsed')).toBeInTheDocument();
   });
 
+  it('renders default and custom entries in the navigation bar', async () => {
+    const defaultEntry = {
+      entityType: 'application',
+      entityName: '#i18n.entityName',
+      endpoint: '/applications',
+      navigationTitle: "#i18n.navigationTitle",
+      formConfig: {
+        name: 'application',
+        fields: [{
+          dataField: 'name',
+          readOnly: true
+        }]
+      },
+      i18n: {
+        de: {
+          entityName: 'Applikation',
+          navigationTitle: 'Applikationen',
+          titleName: 'Name'
+        },
+        en: {
+          entityName: 'Application',
+          navigationTitle: 'Applications',
+          titleName: 'Name'
+        }
+      },
+      tableConfig: {
+        columnDefinition: [{
+          title: '#i18n.titleName',
+          dataIndex: 'name',
+          key: 'name'
+        }]
+      }
+    };
+
+    const customEntry = {
+      entityType: 'myEntity',
+      entityName: '#i18n.entityName',
+      endpoint: '/myEntities',
+      navigationTitle: "#i18n.navigationTitle",
+      formConfig: {
+        name: 'myEntity',
+        fields: [{
+          dataField: 'name',
+          readOnly: true
+        }]
+      },
+      i18n: {
+        de: {
+          entityName: 'MyEntity',
+          navigationTitle: 'MyEntities',
+          titleName: 'Name'
+        },
+        en: {
+          entityName: 'MyEntity',
+          navigationTitle: 'MyEntities',
+          titleName: 'Name'
+        }
+      },
+      tableConfig: {
+        columnDefinition: [{
+          title: '#i18n.titleName',
+          dataIndex: 'name',
+          key: 'name'
+        }]
+      }
+    };
+
+    render(
+      <MemoryRouter>
+        <Navigation
+          entityConfigs={[
+            defaultEntry,
+            customEntry
+          ]}
+        />
+      </MemoryRouter>
+    );
+
+    const applicationEntry = await waitFor(() => screen.getByText('Applications'));
+    const myEntityEntry = await waitFor(() => screen.getByText('MyEntities'));
+
+    expect(applicationEntry).toBeInTheDocument();
+    expect(myEntityEntry).toBeInTheDocument();
+  });
 });

--- a/src/Component/Menu/Navigation/Navigation.tsx
+++ b/src/Component/Menu/Navigation/Navigation.tsx
@@ -8,7 +8,9 @@ import {
   AppstoreOutlined,
   UserOutlined,
   TeamOutlined,
-  FileTextOutlined
+  FileTextOutlined,
+  TagOutlined,
+  ApiOutlined
 } from '@ant-design/icons';
 
 import {
@@ -61,11 +63,22 @@ export const Navigation: React.FC<NavigationProps> = ({
   const navigationContentChildren: ItemType[] = [];
 
   if (entityConfigs && entityConfigs.length > 0) {
-
+    // The following entities are the "default" SHOGun ones.
     const applicationConfig = entityConfigs.find(e => e.entityType === 'application');
     const layersConfig = entityConfigs.find(e => e.entityType === 'layer');
     const userConfig = entityConfigs.find(e => e.entityType === 'user');
     const groupsConfig = entityConfigs.find(e => e.entityType === 'group');
+    const rolesConfig = entityConfigs.find(e => e.entityType === 'role');
+
+    // But it's also possible to add custom entities to the navigation.
+    const otherConfigs = entityConfigs.filter(e => ![
+      applicationConfig,
+      layersConfig,
+      userConfig,
+      groupsConfig,
+      rolesConfig
+    ].includes(e));
+
     if (applicationConfig) {
       navigationContentChildren.push({
         key: 'application',
@@ -118,6 +131,33 @@ export const Navigation: React.FC<NavigationProps> = ({
         )
       });
     }
+    if (rolesConfig) {
+      navigationContentChildren.push({
+        key: 'role',
+        label: (
+          <>
+            <TagOutlined />
+            <span>
+              {TranslationUtil.getTranslationFromConfig(rolesConfig?.navigationTitle, rolesConfig?.i18n)}
+            </span>
+          </>
+        )
+      });
+    }
+    otherConfigs.forEach(entityConfig => {
+      navigationContentChildren.push({
+        key: entityConfig.entityType,
+        label: (
+          <>
+            {/* TODO We might think about making the icon configurable */}
+            <ApiOutlined />
+            <span>
+              {TranslationUtil.getTranslationFromConfig(entityConfig?.navigationTitle, entityConfig?.i18n)}
+            </span>
+          </>
+        )
+      });
+    });
   }
 
   if (navigationConf?.general?.imagefiles?.visible) {

--- a/src/Component/UploadLayerButton/UploadLayerButton.spec.tsx
+++ b/src/Component/UploadLayerButton/UploadLayerButton.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import {
+  cleanup,
+  render
+} from '@testing-library/react';
+
+import { UploadLayerButton } from './UploadLayerButton';
+
+describe('<UploadLayerButton />', () => {
+
+  afterEach(cleanup);
+
+  it('can be rendered', () => {
+    const {
+      container
+    } = render(
+      <UploadLayerButton />);
+
+    expect(container).toBeVisible();
+  });
+});

--- a/src/Component/UploadLayerButton/UploadLayerButton.tsx
+++ b/src/Component/UploadLayerButton/UploadLayerButton.tsx
@@ -1,0 +1,387 @@
+import React, {
+  useState
+} from 'react';
+
+import {
+  UploadOutlined
+} from '@ant-design/icons';
+
+import {
+  notification,
+  Button,
+  Upload
+} from 'antd';
+import {
+  RcFile,
+  UploadChangeParam
+} from 'antd/lib/upload';
+import {
+  UploadFile
+} from 'antd/lib/upload/interface';
+import {
+  UploadRequestOption
+} from 'rc-upload/lib/interface';
+import {
+  Shapefile
+} from 'shapefile.js';
+
+import { ButtonProps } from 'antd/lib/button';
+
+import {
+  getBearerTokenHeader
+} from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
+
+import config from 'shogunApplicationConfig';
+
+import { useTranslation } from 'react-i18next';
+
+import useSHOGunAPIClient from '../../Hooks/useSHOGunAPIClient';
+
+import Logger from '../../Logger';
+
+export type LayerUploadOptions = {
+  baseUrl: string;
+  workspace: string;
+  storeName: string;
+  layerName: string;
+  file: RcFile;
+};
+
+export type LayerUploadResponse = {
+  layerName: string;
+  workspace: string;
+  baseUrl: string;
+};
+
+export type FeatureTypeAttributes = {
+  attribute: {
+    name: string;
+    minOccurs: number;
+    maxOccurs: number;
+    nillable: boolean;
+    binding?: string;
+    length?: number;
+  }[];
+};
+
+export type UploadLayerButtonProps = Omit<ButtonProps, 'onClick' | 'loading'> & {
+  onSuccess?: (layerName?: LayerUploadResponse) => void;
+  onError?: (error: any) => void;
+}
+
+export const UploadLayerButton: React.FC<UploadLayerButtonProps> = ({
+  onSuccess: onSuccessProp,
+  onError: onErrorProp,
+  ...passThroughProps
+}) => {
+
+  const [isUploadingFile, setIsUploadingFile] = useState<boolean>(false);
+
+  const client = useSHOGunAPIClient();
+  const {
+    t
+  } = useTranslation();
+
+  const onBeforeFileUpload = (file: RcFile) => {
+    const maxSize = config.geoserver?.upload?.limit || '200000000';
+    const fileType = file.type;
+    const fileSize = file.size;
+
+    // 1. Check file size
+    if (fileSize > maxSize) {
+      notification.error({
+        message: t('UploadLayerButton.error.message'),
+        description: t('UploadLayerButton.error.descriptionSize', {
+          maxSize: maxSize / 1000000
+        })
+      });
+
+      return false;
+    }
+
+    // 2. Check file format
+    const supportedFormats = ['application/zip', 'application/x-zip-compressed', 'image/tiff'];
+    if (!supportedFormats.includes(fileType)) {
+      notification.error({
+        message: t('UploadLayerButton.error.message'),
+        description: t('UploadLayerButton.error.descriptionFormat', {
+          supportedFormats: supportedFormats.join(', ')
+        })
+      });
+
+      return false;
+    }
+
+    return true;
+  };
+
+  const uploadGeoTiff = async (options: LayerUploadOptions): Promise<void> => {
+    const {
+      baseUrl,
+      workspace,
+      storeName,
+      layerName,
+      file
+    } = options;
+
+    const url = `${baseUrl}/rest/workspaces/${workspace}/coveragestores/` +
+      `${storeName}/file.geotiff?coverageName=${layerName}`;
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        ...getBearerTokenHeader(client?.getKeycloak()),
+        'Content-Type': 'image/tiff'
+      },
+      body: file
+    });
+
+    if (!response.ok) {
+      throw new Error('No successful response while uploading the file');
+    }
+  };
+
+  const uploadShapeZip = async (options: LayerUploadOptions): Promise<void> => {
+    const {
+      baseUrl,
+      workspace,
+      storeName,
+      layerName,
+      file
+    } = options;
+
+    const shp = await Shapefile.load(file);
+
+    let featureTypeName = '';
+    let featureTypeAttributes: FeatureTypeAttributes = {
+      attribute: []
+    };
+
+    if (Object.entries(shp).length !== 1) {
+      throw new Error(t('UploadLayerButton.error.descriptionZipContent'));
+    }
+
+    Object.entries(shp).forEach(([k, v]) => {
+      featureTypeName = k;
+
+      const dbfContent = v.parse('dbf', {
+        properties: false
+      });
+
+      featureTypeAttributes.attribute = dbfContent.fields.map(field => ({
+        name: field.name,
+        minOccurs: 0,
+        maxOccurs: 1,
+        nillable: true,
+        binding: getAttributeType(field.type),
+        length: field.length
+      }));
+
+      const shxContent = v.parse('shx');
+
+      featureTypeAttributes.attribute.push({
+        name: 'the_geom',
+        minOccurs: 0,
+        maxOccurs: 1,
+        nillable: true,
+        binding: getGeometryType(shxContent.header.type)
+      });
+    });
+
+    const url = `${baseUrl}/rest/workspaces/${workspace}/datastores/` +
+      `${storeName}/file.shp?configure=none`;
+
+    const response = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        ...getBearerTokenHeader(client?.getKeycloak()),
+        'Content-Type': 'application/zip'
+      },
+      body: file
+    });
+
+    if (!response.ok) {
+      throw new Error('No successful response while uploading the file');
+    }
+
+    const featureTypeUrl = `${baseUrl}/rest/workspaces/${workspace}/datastores/${storeName}/featuretypes`;
+
+    const featureTypeResponse = await fetch(featureTypeUrl, {
+      method: 'POST',
+      headers: {
+        ...getBearerTokenHeader(client?.getKeycloak()),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        featureType: {
+          enabled: true,
+          name: layerName,
+          nativeName: featureTypeName,
+          title: layerName,
+          attributes: featureTypeAttributes
+        }
+      })
+    });
+
+    if (!featureTypeResponse.ok) {
+      throw new Error('No successful response while creating the featuretype');
+    }
+  };
+
+  const getGeometryType = (geometryTypeNumber: number): string | undefined => {
+    const allTypes: {
+      [key: number]: string | undefined;
+    } = {
+      0: undefined, // Null
+      1: 'org.locationtech.jts.geom.Point', // Point
+      3: 'org.locationtech.jts.geom.LineString', // Polyline
+      5: 'org.locationtech.jts.geom.Polygon', // Polygon
+      8: 'org.locationtech.jts.geom.MultiPoint', // MultiPoint
+      11: 'org.locationtech.jts.geom.Point', // PointZ
+      13: 'org.locationtech.jts.geom.LineString', // PolylineZ
+      15: 'org.locationtech.jts.geom.Polygon', // PolygonZ
+      18: 'org.locationtech.jts.geom.MultiPoint', // MultiPointZ
+      21: 'org.locationtech.jts.geom.Point', // PointM
+      23: 'org.locationtech.jts.geom.LineString', // PolylineM
+      25: 'org.locationtech.jts.geom.Polygon', // PolygonM
+      28: 'org.locationtech.jts.geom.MultiPoint', // MultiPointM
+      31: undefined // MultiPatch
+    };
+
+    return allTypes[geometryTypeNumber];
+  };
+
+  const getAttributeType = (dbfFieldType: string) => {
+    switch (dbfFieldType) {
+      case 'C': // Character
+        return 'java.lang.String';
+      case 'D': // Date
+        return 'java.util.Date';
+      case 'N': // Numeric
+        return 'java.lang.Long';
+      case 'F': // Floating point
+        return 'java.lang.Double';
+      case 'L': // Logical
+        return 'java.lang.Boolean';
+      case 'M': // Memo
+        return undefined;
+      default:
+        return undefined;
+    }
+  };
+
+  const onFileUploadAction = async (options: UploadRequestOption<LayerUploadResponse>) => {
+    const {
+      onError,
+      onSuccess,
+      file
+    } = options;
+
+    const splittedFileName = (file as RcFile).name.split('.');
+    const fileType = (file as RcFile).type;
+    const geoServerBaseUrl = config.geoserver?.base || '/geoserver';
+    const workspace = config.geoserver?.upload?.workspace || 'SHOGUN';
+    const layerName = `${splittedFileName[0]}_${Date.now()}`.toUpperCase();
+
+    const uploadData = {
+      file: file as RcFile,
+      baseUrl: geoServerBaseUrl,
+      workspace: workspace,
+      storeName: layerName,
+      layerName: layerName
+    };
+
+    try {
+      if (fileType === 'image/tiff') {
+        await uploadGeoTiff(uploadData);
+      }
+
+      if (fileType === 'application/zip' || fileType === 'application/x-zip-compressed') {
+        await uploadShapeZip(uploadData);
+      }
+
+      onSuccess?.({
+        baseUrl: geoServerBaseUrl,
+        workspace: workspace,
+        layerName: layerName
+      });
+    } catch (error) {
+      onError?.({
+        name: 'UploadError',
+        message: (error as Error)?.message
+      });
+    }
+  };
+
+  const onFileUploadChange = async (info: UploadChangeParam<UploadFile<LayerUploadResponse>>) => {
+    const file = info.file;
+
+    if (file.status === 'uploading') {
+      setIsUploadingFile(true);
+    }
+
+    if (file.status === 'done') {
+      await client?.layer().add({
+        name: file.response?.layerName ?? 'LAYER-DEFAULT-NAME',
+        type: 'TILEWMS',
+        clientConfig: {
+          hoverable: false
+        },
+        sourceConfig: {
+          url: `${file.response?.baseUrl}/ows?`,
+          layerNames: `${file.response?.workspace}:${file.response?.layerName}`,
+          useBearerToken: true
+        }
+      });
+
+      setIsUploadingFile(false);
+
+      // Finally, show success message
+      notification.success({
+        message: t('UploadLayerButton.success.message'),
+        description: t('UploadLayerButton.success.description', {
+          fileName: file.fileName,
+          layerName: file.response?.layerName
+        }),
+      });
+
+      onSuccessProp?.(file.response);
+    } else if (file.status === 'error') {
+      setIsUploadingFile(false);
+
+      Logger.error(file.error);
+
+      notification.error({
+        message: t('UploadLayerButton.error.message'),
+        description: t('UploadLayerButton.error.description', {
+          fileName: file.fileName
+        })
+      });
+
+      onErrorProp?.(file.error);
+    }
+  };
+
+  return (
+    <Upload
+      customRequest={onFileUploadAction}
+      accept='image/tiff,application/zip'
+      maxCount={1}
+      showUploadList={false}
+      beforeUpload={onBeforeFileUpload}
+      onChange={onFileUploadChange}
+    >
+      <Button
+        type="primary"
+        icon={<UploadOutlined />}
+        loading={isUploadingFile}
+        disabled={isUploadingFile}
+        {...passThroughProps}
+      >
+        {t('UploadLayerButton.title')}
+      </Button>
+    </Upload>
+  );
+};
+
+export default UploadLayerButton;

--- a/src/Context/GeneralEntityRootContext.tsx
+++ b/src/Context/GeneralEntityRootContext.tsx
@@ -1,0 +1,34 @@
+import BaseEntity from '@terrestris/shogun-util/dist/model/BaseEntity';
+import React from 'react';
+
+export type ContextValue<T extends BaseEntity> = {
+  entityType?: string;
+  entityName?: string;
+  fetchEntities?: () => Promise<void>;
+  entities?: T[];
+};
+
+export type GeneralEntityRootProps<T extends BaseEntity> = {
+  value: ContextValue<T>;
+  children: JSX.Element;
+};
+
+// Typing the context here with a generic type T is not possible (or at least I didn't find
+// a proper way to do so). As a workaround, one must type it while using the context, e.g.:
+// const context = useContext<ContextValue<Layer> | undefined>(GeneralEntityRootContext);
+export const GeneralEntityRootContext = React.createContext<(ContextValue<any> | undefined)>(undefined);
+
+export const GeneralEntityRootProvider = <T extends BaseEntity,>({
+  value,
+  children
+}: GeneralEntityRootProps<T>): JSX.Element => {
+  return (
+    <GeneralEntityRootContext.Provider
+      value={value}
+    >
+      {children}
+    </GeneralEntityRootContext.Provider>
+  );
+};
+
+export default GeneralEntityRootContext;

--- a/src/Page/Portal/Portal.tsx
+++ b/src/Page/Portal/Portal.tsx
@@ -36,21 +36,24 @@ import Navigation from '../../Component/Menu/Navigation/Navigation';
 import MetricsRoot from '../../Component/Metrics/MetricsRoot/MetricsRoot';
 import ApplicationInfo from '../../Component/Modal/ApplicationInfo/ApplicationInfo';
 import WelcomeDashboard from '../../Component/WelcomeDashboard/WelcomeDashboard';
+import ToolbarCreateAllUsersButton from '../../Component/GeneralEntity/Slots/ToolbarCreateAllUsersButton/ToolbarCreateAllUsersButton';
+import ToolbarCreateAllGroupsButton from '../../Component/GeneralEntity/Slots/ToolbarCreateAllGroupsButton/ToolbarCreateAllGroupsButton';
+import ToolbarCreateAllRolesButton from '../../Component/GeneralEntity/Slots/ToolbarCreateAllRolesButton/ToolbarCreateAllRolesButton';
+import ToolbarUploadLayerButton from '../../Component/GeneralEntity/Slots/ToolbarUploadLayerButton/ToolbarUploadLayerButton';
 import {
   layerSuggestionListAtom
 } from '../../State/atoms';
 
-interface OwnProps { }
-
-type PortalProps = OwnProps;
+type PortalProps = {};
 
 export const Portal: React.FC<PortalProps> = () => {
   const [collapsed, setCollapsed] = useState<boolean>(false);
-  const toggleCollapsed = () => setCollapsed(!collapsed);
   const [entitiesToLoad, setEntitiesToLoad] = useState<GeneralEntityConfigType<BaseEntity>[]>([]);
   const [configsAreLoading, setConfigsAreLoading] = useState<boolean>(false);
 
   const setLayerSuggestionList = useSetRecoilState(layerSuggestionListAtom);
+
+  const toggleCollapsed = () => setCollapsed(!collapsed);
 
   const fetchConfigForModel = async (modelName: string): Promise<GeneralEntityConfigType<BaseEntity>> => {
     const reqOpts = {
@@ -91,6 +94,21 @@ export const Portal: React.FC<PortalProps> = () => {
     }
   }, [setLayerSuggestionList]);
 
+  const getLeftToolbarItems = (entityType: string): React.ReactNode => {
+    switch (entityType) {
+      case 'layer':
+        return <ToolbarUploadLayerButton />;
+      case 'user':
+        return <ToolbarCreateAllUsersButton />
+      case 'group':
+        return <ToolbarCreateAllGroupsButton />;
+      case 'role':
+        return <ToolbarCreateAllRolesButton />;
+      default:
+        break;
+    }
+  };
+
   if (config?.models && config?.models?.length !== entitiesToLoad?.length && !configsAreLoading) {
     fetchConfigsForModels();
   }
@@ -125,8 +143,11 @@ export const Portal: React.FC<PortalProps> = () => {
                   element={
                     <GeneralEntityRoot
                       key={entityConfig.entityType}
-                      {...entityConfig}
                       onEntitiesLoaded={onEntitiesLoaded}
+                      slots={{
+                        leftToolbar: getLeftToolbarItems(entityConfig.entityType)
+                      }}
+                      {...entityConfig}
                     />
                   }
                 />

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -256,19 +256,19 @@ export default {
       },
       CreateAllUsersButton: {
         title: 'Nutzer synchronisieren',
-        tooltip: 'Add all missing users from the user provider',
+        tooltip: 'Füge alle fehlenden Nutzer aus dem Nutzerprovider hinzu',
         success: 'Nutzer erfolgreich erstellt',
         error: 'Fehler beim Erstellen der Nutzer'
       },
       CreateAllGroupsButton: {
         title: 'Gruppen synchronisieren',
-        tooltip: 'Add all missing users from the user provider',
+        tooltip: 'Füge alle fehlenden Gruppen aus dem Gruppenprovider hinzu',
         success: 'Gruppen erfolgreich erstellt',
         error: 'Fehler beim Erstellen der Gruppen'
       },
       CreateAllRolesButton: {
         title: 'Rollen synchronisieren',
-        tooltip: 'Add all missing users from the user provider',
+        tooltip: 'Füge alle fehlenden Rollen aus dem Rollenprovider hinzu',
         success: 'Rollen erfolgreich erstellt',
         error: 'Fehler beim Erstellen der Rollen'
       }

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -49,20 +49,6 @@ export default {
         save: '{{entity}} speichern',
         reset: '{{entity}} zurücksetzen',
         create: '{{entity}} erstellen',
-        upload: {
-          success: {
-            message: '{{entity}} erfolgreich erstellt',
-            description: 'Datei {{fileName}} wurde erfolgreich geladen und der Layer {{layerName}} erstellt'
-          },
-          error: {
-            message: 'Konnte {{entity}} nicht erstellen',
-            description: 'Fehler beim Hochladen der Datei {{fileName}}',
-            descriptionSize: 'Der Upload überschreitet das Limit von {{maxSize}} MB',
-            descriptionFormat: 'Der Dateityp ist nicht unterstützt ({{supportedFormats}})',
-            descriptionZipContent: 'Mehrere Geodatensätze innerhalb eines Archivs sind nicht unterstützt'
-          },
-          button: '{{entity}} hochladen'
-        },
         reminderModal: {
           title: 'Änderungen speichern?',
           description: 'Die Änderungen wurden noch nicht gespeichert, möchten Sie speichern?',
@@ -250,10 +236,42 @@ export default {
         addLayerErrorMsg: 'Fehler beim Hinzufügen des Layers zur Karte.',
         loadLayerErrorMsg: 'Fehler beim Laden des Layers.',
         extentNotSupportedErrorMsg: 'Zoomen auf Gesamtansicht wird für diesen Typ nicht unterstützt.'
+      },
+      VerifyProviderDetailsField: {
+        title: 'Keine Informationen des Authentication-Providers verfügbar'
+      },
+      UploadLayerButton: {
+        success: {
+          message: 'Layer erfolgreich erstellt',
+          description: 'Datei {{fileName}} wurde erfolgreich geladen und der Layer {{layerName}} erstellt'
+        },
+        error: {
+          message: 'Konnte Layer nicht erstellen',
+          description: 'Fehler beim Hochladen der Datei {{fileName}}',
+          descriptionSize: 'Der Upload überschreitet das Limit von {{maxSize}} MB',
+          descriptionFormat: 'Der Dateityp ist nicht unterstützt ({{supportedFormats}})',
+          descriptionZipContent: 'Mehrere Geodatensätze innerhalb eines Archivs sind nicht unterstützt'
+        },
+        title: 'Layer erstellen'
+      },
+      CreateAllUsersButton: {
+        title: 'Nutzer synchronisieren',
+        tooltip: 'Add all missing users from the user provider',
+        success: 'Nutzer erfolgreich erstellt',
+        error: 'Fehler beim Erstellen der Nutzer'
+      },
+      CreateAllGroupsButton: {
+        title: 'Gruppen synchronisieren',
+        tooltip: 'Add all missing users from the user provider',
+        success: 'Gruppen erfolgreich erstellt',
+        error: 'Fehler beim Erstellen der Gruppen'
+      },
+      CreateAllRolesButton: {
+        title: 'Rollen synchronisieren',
+        tooltip: 'Add all missing users from the user provider',
+        success: 'Rollen erfolgreich erstellt',
+        error: 'Fehler beim Erstellen der Rollen'
       }
-    },
-    VerifyProviderDetailsField: {
-      title: 'Keine Informationen des Authentication-Providers verfügbar'
     }
   },
   en: {
@@ -306,20 +324,6 @@ export default {
         save: 'Save {{entity}}',
         reset: 'Reset {{entity}}',
         create: 'Create {{entity}}',
-        upload: {
-          success: {
-            message: '{{entity}} successfully created',
-            description: 'Successfully uploaded file {{fileName}} and created layer {{layerName}}'
-          },
-          error: {
-            message: 'Could not create {{entity}}',
-            description: 'Error while uploading file {{fileName}}',
-            descriptionSize: 'The file exceeds the upload limit of {{maxSize}} MB',
-            descriptionFormat: 'The given file type does not match the supported ones ({{supportedFormats}})',
-            descriptionZipContent: 'Multiple geodatasets within one archive are not supported'
-          },
-          button: 'Upload {{entity}}'
-        },
         reminderModal: {
           title: 'Save changes?',
           description: 'The changes have not yet been saved, do you want to save?',
@@ -523,6 +527,38 @@ export default {
       },
       VerifyProviderDetailsField: {
         title: 'No authentication provider information available'
+      },
+      UploadLayerButton: {
+        success: {
+          message: 'Layer successfully created',
+          description: 'Successfully uploaded file {{fileName}} and created layer {{layerName}}'
+        },
+        error: {
+          message: 'Could not create layer',
+          description: 'Error while uploading file {{fileName}}',
+          descriptionSize: 'The file exceeds the upload limit of {{maxSize}} MB',
+          descriptionFormat: 'The given file type does not match the supported ones ({{supportedFormats}})',
+          descriptionZipContent: 'Multiple geodatasets within one archive are not supported'
+        },
+        title: 'Create layer'
+      },
+      CreateAllUsersButton: {
+        title: 'Add users',
+        tooltip: 'Add all missing users from the user provider',
+        success: 'Successfully created all users',
+        error: 'Could not create the users'
+      },
+      CreateAllGroupsButton: {
+        title: 'Add groups',
+        tooltip: 'Add all missing groups from the group provider',
+        success: 'Successfully created all groups',
+        error: 'Could not create the groups'
+      },
+      CreateAllRolesButton: {
+        title: 'Add roles',
+        tooltip: 'Add all missing roles from the role provider',
+        success: 'Successfully created all roles',
+        error: 'Could not create the roles'
       }
     }
   }

--- a/src/test-util.tsx
+++ b/src/test-util.tsx
@@ -4,6 +4,11 @@ import * as React from 'react';
 import { render,RenderOptions } from '@testing-library/react';
 import { MutableSnapshot, RecoilRoot } from 'recoil';
 
+// A type to make all properties - except of the specified ones - of
+// an input object optional.
+// Example: PartialOmit<SHOGunAPIClient, 'group'>
+export type PartialOmit<T, K extends keyof T> = Pick<T, K> & Omit<Partial<T>, K>;
+
 const customRender = (ui: React.ReactElement<any, string | React.JSXElementConstructor<any>>,
   recoilInitializer?: ((mutableSnapshot: MutableSnapshot) => void) | undefined,
   options?: RenderOptions<typeof import('@testing-library/dom/types/queries'), HTMLElement, HTMLElement>) => {


### PR DESCRIPTION
This adds a button to each of the `User`, `Group` and `Role` panels to trigger the creation of the given entities from the respective provider (see [#947](https://github.com/terrestris/shogun/pull/947)). Generally it just adds all missing entities, e.g. all users that are present in the user provider (usually Keycloak), but not in SHOGun.

![Peek 2024-11-11 13-18](https://github.com/user-attachments/assets/28030119-91d1-41ee-a3aa-d597d970a32b)

In addition this:

- Refactors the `GeneralEntityRoot` for more flexible and generic support for entity specific components to render (currently only for the toolbar above the entity table, but this might be adjusted for future needs) by introducing a local context including some props that were shared between all sub components.
- Fixes a regression of missing support for additional navigation menu entries besides the default ones.

Requires [#821](https://github.com/terrestris/shogun-util/pull/821).

Please review @terrestris/devs.