### PR TITLE
fix: introduce suggestions for property name

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -45,6 +45,7 @@ import {
   useNavigate
 } from 'react-router-dom';
 
+import { useSetRecoilState } from 'recoil';
 import config from 'shogunApplicationConfig';
 
 import Logger from '@terrestris/base-util/dist/Logger';
@@ -61,6 +62,7 @@ import {
   GenericEntityController
 } from '../../../Controller/GenericEntityController';
 import useSHOGunAPIClient from '../../../Hooks/useSHOGunAPIClient';
+import { entityIdAtom } from '../../../State/atoms';
 import TranslationUtil from '../../../Util/TranslationUtil';
 import GeneralEntityForm, {
   FormConfig
@@ -68,6 +70,7 @@ import GeneralEntityForm, {
 import GeneralEntityTable, {
   TableConfig
 } from '../GeneralEntityTable/GeneralEntityTable';
+
 import './GeneralEntityRoot.less';
 
 export interface GeneralEntityConfigType<T extends BaseEntity> {
@@ -120,6 +123,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
 
   const location = useLocation();
   const navigate = useNavigate();
+  const setEntityId = useSetRecoilState(entityIdAtom);
 
   const match = matchPath({
     path: `${config.appPrefix}/portal/${entityType}/:entityId`
@@ -314,19 +318,22 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   useEffect(() => {
     if (!entityId) {
       setId(undefined);
+      setEntityId(undefined);
       setEditEntity(undefined);
       setFormIsDirty(false);
       return;
     }
     if (entityId === 'create') {
       setId(entityId);
+      setEntityId(undefined);
       form.resetFields();
       form.setFieldsValue(defaultEntity);
     } else {
       setId(parseInt(entityId, 10));
+      setEntityId(parseInt(entityId, 10));
       setFormIsDirty(false);
     }
-  }, [entityId, form, defaultEntity]);
+  }, [entityId, form, defaultEntity, setEntityId]);
 
   // Once the controller is known we need to set the formUpdater so we can update
   // a given form when the entity is updated via controller

--- a/src/Hooks/useExecuteWfsDescribeFeatureType.ts
+++ b/src/Hooks/useExecuteWfsDescribeFeatureType.ts
@@ -1,0 +1,96 @@
+import {
+  useCallback
+} from 'react';
+
+import { UrlUtil } from '@terrestris/base-util/dist/UrlUtil/UrlUtil';
+
+import Layer from '@terrestris/shogun-util/dist/model/Layer';
+import {
+  getBearerTokenHeader
+} from '@terrestris/shogun-util/dist/security/getBearerTokenHeader';
+
+import useSHOGunAPIClient from './useSHOGunAPIClient';
+
+export type LocalGeometryType = 'MultiPoint' | 'Point' | 'MultiLineString' | 'LineString' | 'MultiPolygon' | 'Polygon';
+export type GeometryType = 'gml:MultiPoint' | 'gml:Point' | 'gml:MultiLineString' |
+ 'gml:LineString' | 'gml:MultiPolygon' | 'gml:Polygon';
+
+export interface Property {
+  localType: 'int' | 'number' | 'string' | 'boolean' | 'date' | LocalGeometryType;
+  maxOccurs: 0 | 1;
+  minOccurs: 0 | 1;
+  name: string;
+  nillable: boolean;
+  type: 'xsd:int' | 'xsd:number' | 'xsd:string' | 'xsd:boolean' | 'xsd:date' | GeometryType;
+}
+
+export interface FeatureType {
+  typeName: string;
+  properties: Property[];
+}
+
+export interface DescribeFeatureType {
+  elementFormDefault: string;
+  featureTypes: FeatureType[];
+  targetNamespace: string;
+  targetPrefix: string;
+}
+
+export const isGeometryType = (propertyType: string): propertyType is GeometryType => {
+  const geometryTypes = [
+    'gml:MultiPoint',
+    'gml:Point',
+    'gml:MultiLineString',
+    'gml:LineString',
+    'gml:MultiPolygon',
+    'gml:Polygon'
+  ];
+
+  return geometryTypes.includes(propertyType);
+};
+
+export const useExecuteWfsDescribeFeatureType = () => {
+  const client = useSHOGunAPIClient();
+
+  const executeWfsDescribeFeatureType = useCallback(async (layer: Layer) => {
+    let url = layer.sourceConfig.url;
+
+    if (!url) {
+      return;
+    }
+
+    if (url.endsWith('?')) {
+      url = url.slice(0, -1);
+    }
+
+    const params = {
+      SERVICE: 'WFS',
+      REQUEST: 'DescribeFeatureType',
+      VERSION: '2.0.0',
+      OUTPUTFORMAT: 'application/json',
+      TYPENAMES: layer.sourceConfig.layerNames
+    };
+
+    const defaultHeaders = {
+      'Content-Type': 'application/json'
+    };
+
+    const response = await fetch(`${url}?${UrlUtil.objectToRequestString(params)}`, {
+      method: 'GET',
+      headers: layer.sourceConfig.useBearerToken ? {
+        ...defaultHeaders,
+        ...getBearerTokenHeader(client?.getKeycloak())
+      } : defaultHeaders
+    });
+
+    if (!response.ok) {
+      throw new Error('No successful response while executing a WFS-Transaction');
+    }
+
+    return await response.json() as DescribeFeatureType;
+  }, [client]);
+
+  return executeWfsDescribeFeatureType;
+};
+
+export default useExecuteWfsDescribeFeatureType;

--- a/src/Hooks/useExecuteWfsDescribeFeatureType.ts
+++ b/src/Hooks/useExecuteWfsDescribeFeatureType.ts
@@ -84,7 +84,7 @@ export const useExecuteWfsDescribeFeatureType = () => {
     });
 
     if (!response.ok) {
-      throw new Error('No successful response while executing a WFS-Transaction');
+      throw new Error('No successful response while executing a WFS DescribeFeatureType');
     }
 
     return await response.json() as DescribeFeatureType;

--- a/src/State/atoms.ts
+++ b/src/State/atoms.ts
@@ -33,3 +33,8 @@ export const layerSuggestionListAtom = atom<Layer[]>({
   key: 'layerSuggestionList',
   default: undefined
 });
+
+export const entityIdAtom = atom<number | undefined>({
+  key: 'entityId',
+  default: undefined
+});


### PR DESCRIPTION
This PR introduces a list with suggestions for propertyName in the editFormConfig or featureInfoFormConfig in the layer config in shogun-admin. The suggestions are determined via a WFS-DescribeFeatureType query.

Please note: the suggestion list can only be provided, when the layer is already saved!