### PR TITLE
Optimize (remote) loading behaviours

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -48,7 +48,7 @@ const App: React.FC = () => {
   } = useTranslation();
 
   useEffect(() => {
-    const  setLayers = async() => {
+    const setLayers = async() => {
       try {
         const layers = await client?.layer().findAll();
         if (!_isNil(layers)) {

--- a/src/Component/FormField/Permission/GroupPermissionGrid/GroupPermissionGrid.tsx
+++ b/src/Component/FormField/Permission/GroupPermissionGrid/GroupPermissionGrid.tsx
@@ -1,5 +1,6 @@
 import React, {
-  useCallback
+  useCallback,
+  useMemo
 } from 'react';
 
 import {
@@ -35,21 +36,51 @@ const GroupPermissionGrid: React.FC<GroupPermissionGridProps> = ({
     return client?.[entityType].apply(client);
   }, [client, entityType]);
 
-  const getGroupInstancePermissions = async (id: number) => {
+  const getGroupInstancePermissions = useCallback(async (id: number) => {
     return await service()?.getGroupInstancePermissions(id);
-  };
+  }, [service]);
 
-  const setGroupInstancePermission = async (id: number, referenceId: number, permission: PermissionCollectionType) => {
+  const setGroupInstancePermission = useCallback(async (id: number, referenceId: number,
+    permission: PermissionCollectionType) => {
     await service()?.setGroupInstancePermission(id, referenceId, permission);
-  };
+  }, [service]);
 
-  const deleteGroupInstancePermission = async (id: number, referenceId: number) => {
+  const deleteGroupInstancePermission = useCallback(async (id: number, referenceId: number) => {
     await service()?.deleteGroupInstancePermission(id, referenceId);
-  };
+  }, [service]);
 
-  const getGroups = async (pageOpts?: PageOpts) => {
+  const getGroups = useCallback(async (pageOpts?: PageOpts) => {
     return await client?.group().findAll(pageOpts);
-  };
+  }, [client]);
+
+  const modalProps = useMemo(() => ({
+    toTag: (group: Group) => {
+      return {
+        value: group.id,
+        filterValues: [
+          group.id,
+          group.authProviderId,
+          group.providerDetails?.name
+        ],
+        label: (
+          <span>{group.providerDetails?.name || `ID: ${group.id}`}</span>
+        )
+      };
+    },
+    getReferences: getGroups,
+    setInstancePermission: setGroupInstancePermission,
+    descriptionText: t('GroupPermissionGrid.modal.description'),
+    referenceLabelText: t('GroupPermissionGrid.modal.referenceSelectLabel'),
+    referenceExtraText: t('GroupPermissionGrid.modal.referenceSelectExtra'),
+    referenceSelectPlaceholderText: t('GroupPermissionGrid.modal.referenceSelectPlaceholder'),
+    permissionSelectLabel: t('GroupPermissionGrid.modal.permissionSelectLabel'),
+    permissionSelectExtra: t('GroupPermissionGrid.modal.permissionSelectExtra'),
+    saveErrorMsg: (placeholder: string) => {
+      return t('GroupPermissionGrid.modal.saveErrorMsg', {
+        referenceIds: placeholder
+      });
+    }
+  }), [getGroups, setGroupInstancePermission, t]);
 
   const toGroupDataType = (permission: GroupInstancePermission): DataType<Group> => {
     return {
@@ -57,20 +88,6 @@ const GroupPermissionGrid: React.FC<GroupPermissionGridProps> = ({
       reference: permission.group,
       name: permission.group?.providerDetails?.name,
       permission: permission.permission?.name
-    };
-  };
-
-  const toTag = (group: Group) => {
-    return {
-      value: group.id,
-      filterValues: [
-        group.id,
-        group.authProviderId,
-        group.providerDetails?.name
-      ],
-      label: (
-        <span>{group.providerDetails?.name}</span>
-      )
     };
   };
 
@@ -97,22 +114,7 @@ const GroupPermissionGrid: React.FC<GroupPermissionGridProps> = ({
       deleteInstancePermission={deleteGroupInstancePermission}
       toDataType={toGroupDataType}
       nameColumnDefinition={colDefinition()}
-      modalProps={{
-        toTag: toTag,
-        getReferences: getGroups,
-        setInstancePermission: setGroupInstancePermission,
-        descriptionText: t('GroupPermissionGrid.modal.description'),
-        referenceLabelText: t('GroupPermissionGrid.modal.referenceSelectLabel'),
-        referenceExtraText: t('GroupPermissionGrid.modal.referenceSelectExtra'),
-        referenceSelectPlaceholderText: t('GroupPermissionGrid.modal.referenceSelectPlaceholder'),
-        permissionSelectLabel: t('GroupPermissionGrid.modal.permissionSelectLabel'),
-        permissionSelectExtra: t('GroupPermissionGrid.modal.permissionSelectExtra'),
-        saveErrorMsg: (placeholder: string) => {
-          return t('GroupPermissionGrid.modal.saveErrorMsg', {
-            referenceIds: placeholder
-          });
-        }
-      }}
+      modalProps={modalProps}
       {...passThroughProps}
     />
   );

--- a/src/Component/FormField/Permission/InstancePermissionGrid/InstancePermissionGrid.tsx
+++ b/src/Component/FormField/Permission/InstancePermissionGrid/InstancePermissionGrid.tsx
@@ -71,7 +71,7 @@ export interface InstancePermissionGridProps<E extends InstancePermission> exten
   modalProps: Omit<PermissionModalProps, 'entityId' | 'entityType'>;
 }
 
-export const InstancePermissionGrid = <T, E extends InstancePermission>({
+export const InstancePermissionGrid = <E extends InstancePermission>({
   entityId,
   getInstancePermissions,
   setInstancePermission,

--- a/src/Component/FormField/Permission/PermissionModal/PermissionModal.spec.tsx
+++ b/src/Component/FormField/Permission/PermissionModal/PermissionModal.spec.tsx
@@ -68,8 +68,5 @@ describe('<PermissionModal />', () => {
         }}
       />);
     expect(container).toBeVisible();
-    await waitFor(() => {
-      expect(screen.getAllByText('PermissionModal.loadErrorMsg')[0]).toBeInTheDocument();
-    });
   });
 });

--- a/src/Component/FormField/Permission/PermissionModal/PermissionModal.tsx
+++ b/src/Component/FormField/Permission/PermissionModal/PermissionModal.tsx
@@ -1,4 +1,5 @@
 import React, {
+  useCallback,
   useEffect,
   useState
 } from 'react';
@@ -82,11 +83,12 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
   saveErrorMsg = () => '',
   ...passThroughProps
 }) => {
-  const [loading, setLoading] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
+  const [isSelectMenuOpen, setIsSelectMenuOpen] = useState(false);
   const [references, setReferences] = useState<(User | Group | Role)[]>([]);
   const [options, setOptions] = useState<DefaultOptionType[]>();
-  const [visible, setVisible] = useState(false);
+  const [isVisible, setIsVisible] = useState(false);
 
   const [referencePage, setReferencePage] = useState<number>(1);
   const [referenceTotal, setReferenceTotal] = useState<number>();
@@ -96,35 +98,38 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
 
   const referencePageSize = 20;
 
-  useEffect(() => {
+  const loadReferences = useCallback(async () => {
     if (!getReferences) {
       return;
     }
 
-    (async () => {
-      setLoading(true);
+    setIsLoading(true);
 
-      try {
-        const refs = await getReferences({
-          page: referencePage - 1,
-          size: referencePageSize
-        });
+    try {
+      const refs = await getReferences({
+        page: referencePage - 1,
+        size: referencePageSize
+      });
 
-        if (!refs) {
-          throw new Error('Failed to load references');
-        }
-
-        setReferenceTotal(refs.totalElements);
-        setReferencePage(refs.number + 1);
-        setReferences(refs.content);
-      } catch (error) {
-        message.error(t('PermissionModal.loadErrorMsg'));
-        Logger.error(error);
-      } finally {
-        setLoading(false);
+      if (!refs) {
+        throw new Error('Failed to load references');
       }
-    })();
+
+      setReferenceTotal(refs.totalElements);
+      setReferences(refs.content);
+    } catch (error) {
+      message.error(t('PermissionModal.loadErrorMsg'));
+      Logger.error(error);
+    } finally {
+      setIsLoading(false);
+    }
   }, [getReferences, t, referencePage]);
+
+  useEffect(() => {
+    if (isSelectMenuOpen) {
+      loadReferences();
+    }
+  }, [isSelectMenuOpen, loadReferences]);
 
   useEffect(() => {
     if (Array.isArray(references)) {
@@ -133,12 +138,12 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
   }, [references, toTag]);
 
   const onClick = () => {
-    setVisible(!visible);
+    setIsVisible(!isVisible);
   };
 
   const onCancel = () => {
     form.resetFields();
-    setVisible(false);
+    setIsVisible(false);
   };
 
   const onOk = async () => {
@@ -173,13 +178,34 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
 
     form.resetFields();
     setIsSaving(false);
-    setVisible(false);
+    setIsVisible(false);
     onSave();
   };
 
-  const onPaginationChange = (page: number) => {
-    setReferencePage(page);
-  };
+  const dropdownRender = useCallback((menu: React.ReactElement) => (
+    <div
+      className="permission-modal-reference-dropdown"
+    >
+      {menu}
+      <Divider />
+      <Pagination
+        total={referenceTotal}
+        showTotal={total => `${t('PermissionModal.paginationTotal')}: ${total}`}
+        locale={{
+          // eslint-disable-next-line camelcase
+          next_page: t('PermissionModal.paginationNextPage'),
+          // eslint-disable-next-line camelcase
+          prev_page: t('PermissionModal.paginationPrevPage')
+        }}
+        onChange={page => {
+          setReferencePage(page);
+        }}
+        current={referencePage}
+        pageSize={referencePageSize}
+        size="small"
+      />
+    </div>
+  ), [referencePage, referenceTotal, t]);
 
   return (
     <>
@@ -195,7 +221,7 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
       <Modal
         className="permission-modal"
         title={t('PermissionModal.title')}
-        open={visible}
+        open={isVisible}
         onCancel={onCancel}
         onOk={onOk}
         okButtonProps={{
@@ -228,31 +254,14 @@ const PermissionModal: React.FC<PermissionModalProps> = ({
               allowClear
               optionFilterProp={'filterValues'}
               placeholder={referenceSelectPlaceholderText}
-              loading={loading}
+              open={isSelectMenuOpen}
+              loading={isLoading}
+              onDropdownVisibleChange={() => {
+                setIsSelectMenuOpen(!isSelectMenuOpen);
+              }}
               options={options}
               tagRender={tagRenderer}
-              dropdownRender={menu => (
-                <div
-                  className="permission-modal-reference-dropdown"
-                >
-                  {menu}
-                  <Divider />
-                  <Pagination
-                    total={referenceTotal}
-                    showTotal={total => `${t('PermissionModal.paginationTotal')}: ${total}`}
-                    locale={{
-                      // eslint-disable-next-line camelcase
-                      next_page: t('PermissionModal.paginationNextPage'),
-                      // eslint-disable-next-line camelcase
-                      prev_page: t('PermissionModal.paginationPrevPage')
-                    }}
-                    onChange={onPaginationChange}
-                    current={referencePage}
-                    pageSize={referencePageSize}
-                    size='small'
-                  />
-                </div>
-              )}
+              dropdownRender={dropdownRender}
             />
           </Form.Item>
           <Form.Item

--- a/src/Component/FormField/Permission/UserPermissionGrid/UserPermissionGrid.tsx
+++ b/src/Component/FormField/Permission/UserPermissionGrid/UserPermissionGrid.tsx
@@ -1,5 +1,6 @@
 import React, {
-  useCallback
+  useCallback,
+  useMemo
 } from 'react';
 
 import {
@@ -46,21 +47,75 @@ const UserPermissionGrid: React.FC<UserPermissionGridProps> = ({
     return client?.[entityType].apply(client);
   }, [client, entityType]);
 
-  const getUserInstancePermissions = async (id: number) => {
+  const getUserInstancePermissions = useCallback(async (id: number) => {
     return await service()?.getUserInstancePermissions(id);
-  };
+  }, [service]);
 
-  const setUserInstancePermission = async (id: number, referenceId: number, permission: PermissionCollectionType) => {
+  const setUserInstancePermission = useCallback(async (id: number, referenceId: number,
+    permission: PermissionCollectionType) => {
     await service()?.setUserInstancePermission(id, referenceId, permission);
-  };
+  }, [service]);
 
-  const deleteUserInstancePermission = async (id: number, referenceId: number) => {
+  const deleteUserInstancePermission = useCallback(async (id: number, referenceId: number) => {
     await service()?.deleteUserInstancePermission(id, referenceId);
-  };
+  }, [service]);
 
-  const getUsers = async (pageOpts?: PageOpts) => {
+  const getUsers = useCallback(async (pageOpts?: PageOpts) => {
     return client?.user().findAll(pageOpts);
-  };
+  }, [client]);
+
+  const modalProps = useMemo(() => ({
+    toTag: (user: User) => {
+      return {
+        value: user.id,
+        filterValues: [
+          user.providerDetails?.firstName,
+          user.providerDetails?.lastName,
+          user.providerDetails?.username,
+          user.providerDetails?.email
+        ],
+        label: (
+          <UserAvatar
+            user={user}
+          />
+        )
+      };
+    },
+    getReferences: getUsers,
+    tagRenderer: (props: CustomTagProps) => {
+      const {
+        label,
+        ...passProps
+      } = props;
+
+      const onPreventMouseDown = (event: React.MouseEvent<HTMLSpanElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+      };
+
+      return (
+        <Tag
+          onMouseDown={onPreventMouseDown}
+          className="user-avatar-tag"
+          {...passProps}
+        >
+          {label}
+        </Tag>
+      );
+    },
+    setInstancePermission: setUserInstancePermission,
+    descriptionText: t('UserPermissionGrid.modal.description'),
+    referenceLabelText: t('UserPermissionGrid.modal.referenceSelectLabel'),
+    referenceExtraText: t('UserPermissionGrid.modal.referenceSelectExtra'),
+    referenceSelectPlaceholderText: t('UserPermissionGrid.modal.referenceSelectPlaceholder'),
+    permissionSelectLabel: t('UserPermissionGrid.modal.permissionSelectLabel'),
+    permissionSelectExtra: t('UserPermissionGrid.modal.permissionSelectExtra'),
+    saveErrorMsg: (placeholder: string) => {
+      return t('UserPermissionGrid.modal.saveErrorMsg', {
+        referenceIds: placeholder
+      });
+    }
+  }), [getUsers, setUserInstancePermission, t]);
 
   const toUserDataType = (permission: UserInstancePermission): DataType<User> => {
     return {
@@ -69,45 +124,6 @@ const UserPermissionGrid: React.FC<UserPermissionGridProps> = ({
       name: permission.user?.providerDetails?.username,
       permission: permission.permission?.name
     };
-  };
-
-  const toTag = (user: User) => {
-    return {
-      value: user.id,
-      filterValues: [
-        user.providerDetails?.firstName,
-        user.providerDetails?.lastName,
-        user.providerDetails?.username,
-        user.providerDetails?.email
-      ],
-      label: (
-        <UserAvatar
-          user={user}
-        />
-      )
-    };
-  };
-
-  const tagRenderer = (props: CustomTagProps) => {
-    const {
-      label,
-      ...passProps
-    } = props;
-
-    const onPreventMouseDown = (event: React.MouseEvent<HTMLSpanElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
-    };
-
-    return (
-      <Tag
-        onMouseDown={onPreventMouseDown}
-        className="user-avatar-tag"
-        {...passProps}
-      >
-        {label}
-      </Tag>
-    );
   };
 
   const colDefinition = () => {
@@ -138,23 +154,7 @@ const UserPermissionGrid: React.FC<UserPermissionGridProps> = ({
       deleteInstancePermission={deleteUserInstancePermission}
       toDataType={toUserDataType}
       nameColumnDefinition={colDefinition()}
-      modalProps={{
-        toTag: toTag,
-        getReferences: getUsers,
-        tagRenderer: tagRenderer,
-        setInstancePermission: setUserInstancePermission,
-        descriptionText: t('UserPermissionGrid.modal.description'),
-        referenceLabelText: t('UserPermissionGrid.modal.referenceSelectLabel'),
-        referenceExtraText: t('UserPermissionGrid.modal.referenceSelectExtra'),
-        referenceSelectPlaceholderText: t('UserPermissionGrid.modal.referenceSelectPlaceholder'),
-        permissionSelectLabel: t('UserPermissionGrid.modal.permissionSelectLabel'),
-        permissionSelectExtra: t('UserPermissionGrid.modal.permissionSelectExtra'),
-        saveErrorMsg: (placeholder: string) => {
-          return t('UserPermissionGrid.modal.saveErrorMsg', {
-            referenceIds: placeholder
-          });
-        }
-      }}
+      modalProps={modalProps}
       {...passThroughProps}
     />
   );


### PR DESCRIPTION
Currently loading the list of entities and an entity itself (e.g. the list of applications and selection an application from the list) results in a lot of duplicated or unwanted requests to the backend fetching the payload multiple times or too early.

This fixes several of the observed loading behaviours by:

- applying the default sorter as default state value to reduce the initial loading of the entity lists to a singel request.
- caching the `modalProps` in the instance permission grids to prevent unwanted rerenders (the previous approach was creating new object reference on each render). 
- load the users/groups/roles in the permission grids as lazy as possible (by opening the select dropdown only).

In addition it removes the custom `tagRenderer` from the role permission grid - probably a copy paste error.

Please review @terrestris/devs.