### PR TITLE
Minor style adjustments to the permission grids

### DIFF
--- a/src/Component/FormField/Permission/UserPermissionGrid/UserPermissionGrid.less
+++ b/src/Component/FormField/Permission/UserPermissionGrid/UserPermissionGrid.less
@@ -3,14 +3,19 @@
     display: flex;
     align-items: center;
 
+    background: var(--ant-select-multiple-item-bg);
+    border: var(--ant-line-width) var(--ant-line-type) var(--ant-select-multiple-item-border-color);
+    cursor: default;
+    margin-inline-end: calc(var(--ant-select-internal_fixed_item_margin)* 2);
+
     .user-avatar {
       display: flex;
       align-items: center;
 
       .user-avatar-image {
         margin-right: 10px;
-        height: 25px;
-        width: 25px;
+        height: 22px;
+        width: 22px;
       }
 
       div.user-avatar-name {
@@ -19,7 +24,8 @@
 
         > span:first-child {
           margin-right: 5px;
-          font-weight: unset;
+          font-weight: normal;
+          font-size: var(--ant-font-size);
         }
 
         > span:nth-of-type(2) {

--- a/src/Component/FormField/Permission/UserPermissionGrid/UserPermissionGrid.tsx
+++ b/src/Component/FormField/Permission/UserPermissionGrid/UserPermissionGrid.tsx
@@ -97,6 +97,7 @@ const UserPermissionGrid: React.FC<UserPermissionGridProps> = ({
         <Tag
           onMouseDown={onPreventMouseDown}
           className="user-avatar-tag"
+          bordered={false}
           {...passProps}
         >
           {label}

--- a/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
@@ -25,6 +25,8 @@ import Logger from 'js-logger';
 
 import _cloneDeep from 'lodash/cloneDeep';
 
+import { useTranslation } from 'react-i18next';
+
 import GeneralEntityRootContext, {
   ContextValue
 } from '../../../Context/GeneralEntityRootContext';
@@ -92,6 +94,10 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
 }) => {
 
   const generalEntityRootContext = useContext<ContextValue<any> | undefined>(GeneralEntityRootContext);
+
+  const {
+    t
+  } = useTranslation();
 
   /**
    * Create read-only components for certain form items
@@ -197,7 +203,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
         );
       case 'UserPermissionGrid':
         if (entityId !== form.getFieldValue('id')) {
-          return undefined;
+          return t('GeneralEntityForm.userPermissionGridNoIdWarning');
         }
 
         return (
@@ -209,7 +215,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
         );
       case 'GroupPermissionGrid':
         if (entityId !== form.getFieldValue('id')) {
-          return undefined;
+          return t('GeneralEntityForm.groupPermissionGridNoIdWarning');
         }
 
         return (
@@ -221,7 +227,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
         );
       case 'RolePermissionGrid':
         if (entityId !== form.getFieldValue('id')) {
-          return undefined;
+          return t('GeneralEntityForm.rolePermissionGridNoIdWarning');
         }
 
         return (

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -87,6 +87,14 @@ export default {
           total: 'Total'
         }
       },
+      GeneralEntityForm: {
+        userPermissionGridNoIdWarning: 'Die Konfiguration muss gespeichert werden, ' +
+          'bevor die Benutzerberechtigungen festgelegt werden können.',
+        groupPermissionGridNoIdWarning: 'Die Konfiguration muss gespeichert werden, ' +
+          'bevor die Gruppenberechtigungen festgelegt werden können.',
+        rolePermissionGridNoIdWarning: 'Die Konfiguration muss gespeichert werden, ' +
+          'bevor die Rollenberechtigungen festgelegt werden können.'
+      },
       ImageFileRoot: {
         title: 'Bilddateien',
         subTitle: '… die die Welt zeigen',
@@ -363,6 +371,11 @@ export default {
           page: 'Page',
           total: 'Total'
         }
+      },
+      GeneralEntityForm: {
+        userPermissionGridNoIdWarning: 'Configuration must be saved before the user permissions can be set.',
+        groupPermissionGridNoIdWarning: 'Configuration must be saved before the group permissions can be set.',
+        rolePermissionGridNoIdWarning: 'Configuration must be saved before the role permissions can be set.'
       },
       ImageFileRoot: {
         title: 'Images',


### PR DESCRIPTION
This updates the style of the permissions grids:

1. Show a note if the grids can't be shown in create mode.

  - Before:

  ![image](https://github.com/user-attachments/assets/041ddea4-a03b-4abc-9cff-f9eeaa1881bb)

  - After:

  ![image](https://github.com/user-attachments/assets/c2d0ce70-4c64-40a2-9f5b-c003601931c9)

2. Update the custom tag style for users to the default ones in the select input field:

  - Before:

  ![image](https://github.com/user-attachments/assets/6f6dab6a-20fd-4a13-b177-bab7f2e79c00)

  - After:

  ![image](https://github.com/user-attachments/assets/3259f2a6-8126-428b-ba74-0f60d450f53a)

  - Compared to the default tags:

  ![image](https://github.com/user-attachments/assets/06cfcd75-f91d-450d-9bf1-8ba7e41c2735)

Please review @terrestris/devs.