### PR TITLE
Fix entity templates

### DIFF
--- a/rspack.common.js
+++ b/rspack.common.js
@@ -19,6 +19,7 @@ module.exports = {
   },
   output: {
     path: path.resolve(__dirname, 'dist'),
+    publicPath: 'auto',
     clean: true
   },
   resolve: {
@@ -135,6 +136,7 @@ module.exports = {
     }),
     new ModuleFederationPlugin({
       name: 'SHOGunAdmin',
+      dev: false,
       shared: {
         react: {
           singleton: true,

--- a/src/Controller/ControllerUtil.ts
+++ b/src/Controller/ControllerUtil.ts
@@ -17,7 +17,7 @@ export interface ControllerCfg {
   entityType: string;
   formConfig: FormConfig;
   keycloak?: Keycloak;
-  updateForm?: (values: FormValues) => void;
+  formValidator?: (values: FormValues) => void;
 }
 
 export class ControllerUtil {
@@ -27,7 +27,7 @@ export class ControllerUtil {
     keycloak,
     entityType,
     formConfig,
-    updateForm
+    formValidator
   }: ControllerCfg): GenericEntityController<BaseEntity> {
     switch (_lowerCase(entityType)) {
       case 'application':
@@ -37,7 +37,7 @@ export class ControllerUtil {
             keycloak,
             entityType: 'application',
             formConfig,
-            updateForm
+            formValidator
           });
       default:
         return ControllerUtil
@@ -46,7 +46,7 @@ export class ControllerUtil {
             keycloak,
             entityType,
             formConfig,
-            updateForm
+            formValidator
           });
     }
   }
@@ -63,7 +63,7 @@ export class ControllerUtil {
     });
     return new GenericEntityController<Application>({
       service: appService,
-      formUpdater: controllerCfg?.updateForm,
+      formValidator: controllerCfg?.formValidator,
       formConfig: controllerCfg?.formConfig
     });
   }
@@ -80,7 +80,7 @@ export class ControllerUtil {
     });
     return new GenericEntityController<BaseEntity>({
       service: genericService as GenericEntityService<BaseEntity>,
-      formUpdater: controllerCfg?.updateForm,
+      formValidator: controllerCfg?.formValidator,
       formConfig: controllerCfg?.formConfig
     });
   }


### PR DESCRIPTION
This fixes an annoying bug while creating a new entity (e.g. an application configuration) in environments where a `defaultEntity` is set. In such scenarios any user input to the configuration template will be overwritten on save.

In addition it fixes an error in the rspack configuration.

Please review @terrestris/devs.