### PR TITLE
feat: introduce regulary updated docker images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,13 +6,13 @@ on:
     branches:
       - next
 
-env:
-  DOCKER_REGISTRY: docker-public.terrestris.de/terrestris
-
 jobs:
-  release:
+  release-npm:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: Checkout sources 🔰
         uses: actions/checkout@v4
@@ -33,64 +33,12 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         with:
           semantic_version: 23
-
-      - name: Login to Nexus
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.DOCKER_REGISTRY }}
-          username: ${{ secrets.NEXUS_USERNAME }}
-          password: ${{ secrets.NEXUS_PASSWORD }}
-
-      - name: Build docker image (latest)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-admin:latest
-          load: true
-
-      - name: Build docker image (version)
-        if: steps.semantic.outputs.new_release_published == 'true'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-admin:${{ steps.semantic.outputs.new_release_version }}
-          load: true
-
-      - name: Push docker image to Nexus (latest)
-        run: |
-          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin:latest
-
-      - name: Push docker image to Nexus (version)
-        if: steps.semantic.outputs.new_release_published == 'true'
-        run: |
-          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin:${{ steps.semantic.outputs.new_release_version }}
-
-      - name: Build docker image e2e-tests (latest) 🏗️
-        uses: docker/build-push-action@v6
-        with:
-          file: Dockerfile.e2e
-          context: .
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:latest
-          load: true
-
-      - name: Build docker image e2e-tests (version) 🏗️
-        if: steps.semantic.outputs.new_release_published == 'true'
-        uses: docker/build-push-action@v6
-        with:
-          file: Dockerfile.e2e
-          context: .
-          tags: |
-            ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:${{ steps.semantic.outputs.new_release_version }}
-          load: true
-
-      - name: Push docker image to Nexus e2e-tests (latest) 📠
-        run: |
-          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:latest
-
-      - name: Push docker image to Nexus e2e-tests (version) 📠
-        if: steps.semantic.outputs.new_release_published == 'true'
-        run: |
-          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:${{ steps.semantic.outputs.new_release_version }}
+  release-docker:
+    needs: release-npm
+    uses: ./.github/workflows/release_docker.yml
+    with:
+      release_is_published: ${{ needs.release-npm.outputs.new_release_published }}
+      release_version: ${{ needs.release-npm.outputs.new_release_version }}
+    secrets:
+      nexus_user: ${{ secrets.NEXUS_USERNAME}}
+      nexus_pass: ${{ secrets.NEXUS_USERNAME}}

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -1,0 +1,90 @@
+name: Release Docker
+
+on:
+  workflow_call: # allows being called by other workflows
+    inputs:
+      release_is_published:
+        required: true
+        type: boolean
+      release_version:
+        required: true
+        type: string
+    secrets:
+      nexus_user:
+        required: true
+      nexus_pass:
+        required: true
+
+env:
+  DOCKER_REGISTRY: docker-public.terrestris.de/terrestris
+
+jobs:
+  release-docker:
+    name: Release Docker
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources 🔰
+        uses: actions/checkout@v4
+        with:
+          ref: v${{ inputs.release_version }}
+
+      - name: Login to Nexus
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.DOCKER_REGISTRY }}
+          username: ${{ secrets.nexus_user }}
+          password: ${{ secrets.nexus_pass }}
+
+      - name: Build docker image (latest)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/shogun-admin:latest
+          load: true
+
+      - name: Build docker image (version)
+        if: ${{ inputs.release_is_published }} == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/shogun-admin:${{ inputs.release_version }}
+          load: true
+
+      - name: Push docker image to Nexus (latest)
+        run: |
+          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin:latest
+
+      - name: Push docker image to Nexus (version)
+        if: ${{ inputs.release_is_published }} == 'true'
+        run: |
+          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin:${{ inputs.release_version }}
+
+      - name: Build docker image e2e-tests (latest) 🏗️
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile.e2e
+          context: .
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:latest
+          load: true
+
+      - name: Build docker image e2e-tests (version) 🏗️
+        if: ${{ inputs.release_is_published }} == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile.e2e
+          context: .
+          tags: |
+            ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:${{ inputs.release_version }}
+          load: true
+
+      - name: Push docker image to Nexus e2e-tests (latest) 📠
+        run: |
+          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:latest
+
+      - name: Push docker image to Nexus e2e-tests (version) 📠
+        if: ${{ inputs.release_is_published }} == 'true'
+        run: |
+          docker push ${{ env.DOCKER_REGISTRY }}/shogun-admin-client-e2e-tests:${{ inputs.release_version }}

--- a/.github/workflows/update_base_images.yaml
+++ b/.github/workflows/update_base_images.yaml
@@ -1,0 +1,46 @@
+name: Update docker base images
+
+on:
+  workflow_dispatch: # allow manual trigger
+  schedule:
+    - cron: '0 3 * * 0'  # every sunday at 03:00 UTC
+
+jobs:
+  latest-tags:
+    runs-on: ubuntu-latest
+    outputs:
+      main_tag: ${{ steps.main_tag.outputs.result }}
+      next_tag: ${{ steps.next_tag.outputs.result }}
+    steps:
+      - name: Checkout sources 🔰
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # tags only
+
+      - name: Get latest main tag
+        id: main_tag
+        run: echo "result=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 | sed 's/^v//')" >> $GITHUB_ENV
+
+      - name: Get latest next tag
+        id: next_tag
+        run: echo "result=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-next\.[0-9]+)?$' | sort -V | tail -n1 | sed 's/^v//')" >> $GITHUB_ENV
+
+  update-docker-main:
+    needs: latest-tags
+    uses: ./.github/workflows/release_docker.yml
+    with:
+      release_is_published: true
+      release_version: ${{ needs.latest-tags.outputs.main_tag }}
+    secrets:
+      nexus_user: ${{ secrets.NEXUS_USERNAME}}
+      nexus_pass: ${{ secrets.NEXUS_USERNAME}}
+
+  update-docker-next:
+    needs: latest-tags
+    uses: ./.github/workflows/release_docker.yml
+    with:
+      release_is_published: true
+      release_version: ${{ needs.latest-tags.outputs.next_tag }}
+    secrets:
+      nexus_user: ${{ secrets.NEXUS_USERNAME}}
+      nexus_pass: ${{ secrets.NEXUS_USERNAME}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # build environment
 FROM node:23.3.0-alpine3.19 AS build
 
+RUN apk update && apk upgrade --no-cache
+
 WORKDIR /app
 
 COPY . .
@@ -9,6 +11,8 @@ RUN npm run build
 
 # production environment
 FROM nginx:1.27.4-alpine-slim
+
+RUN apk update && apk upgrade --no-cache
 
 COPY --from=build /app/dist /var/www/html
 COPY --from=build /app/nginx/templates /etc/nginx/templates

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,7 @@
 FROM node:23.3.0-alpine3.19
 
+RUN apk update && apk upgrade --no-cache
+
 WORKDIR /app
 
 EXPOSE 8080


### PR DESCRIPTION
This introduces regulary (cronjob based) updates of the base images:

* add `RUN apk update && apk upgrade --no-cache` after all base images
* extract a new "release docker" workflow that can be called by other workflows
  * as before: for releases (also next branch)
  * in future: use by another new workflow "update base images" that will regulary update the base images