### PR TITLE
Don't throw error in catch

### DIFF
--- a/src/Component/Logs/Logs.tsx
+++ b/src/Component/Logs/Logs.tsx
@@ -24,7 +24,6 @@ import LogService from '../../Service/LogService/LogService';
 
 import './Logs.less';
 
-
 interface LogsProps {}
 
 export const Logs: React.FC<LogsProps> = () => {

--- a/src/Service/LogService/LogService.ts
+++ b/src/Service/LogService/LogService.ts
@@ -94,7 +94,6 @@ class LogService {
       return await logResponse.text();
     } catch (error) {
       Logger.error(`Error while reading the logs: ${error}`);
-      return Promise.reject();
     }
   };
 


### PR DESCRIPTION
This fixes a minor issue of an uncatched error in the `Logs` component if the logfile can't be fetched (e.g. in the development setup) by not rethrowing/rejecting in the service's catch clause.

Please review @terrestris/devs.