### PR TITLE
ci: fix coverage comment

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -66,12 +66,20 @@ jobs:
           fi
 
       - name: Construct jest coverage comment input 💬
+        if: ${{ github.actor != 'dependabot[bot]' }}
         id: construct-input
+        env:
+          MULTI_LINES_TEXT: |
+            All, ./coverage/all/coverage-summary.json
+            only changed, ./coverage/changed/coverage-summary.json
         run: |
           if [ "${{ env.no_tests_found }}" == "true" ]; then
             echo "MULTIPLE_FILES=All, ./coverage/all/coverage-summary.json" >> $GITHUB_ENV
           else
-            echo "MULTIPLE_FILES=All, ./coverage/all/coverage-summary.json\nonly changed, ./coverage/changed/coverage-summary.json" >> $GITHUB_ENV
+            echo "MULTIPLE_FILES<<EOF" >> $GITHUB_ENV
+            echo "$MULTI_LINES_TEXT" >> $GITHUB_ENV
+            echo "EOF" >> $GITHUB_ENV
+            cat $GITHUB_ENV
           fi
 
       - name: Jest Coverage Comment 💬
@@ -85,7 +93,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Get Coverage Comment Id ➡️
-        if: env.no_tests_found == 'true'
+        if: ${{ env.no_tests_found == 'true' && github.actor != 'dependabot[bot]' }}
         id: get-comment-id
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
@@ -97,7 +105,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Post To No Tests Found Comment ⚠️
-        if: env.no_tests_found == 'true'
+        if: ${{ env.no_tests_found == 'true' && github.actor != 'dependabot[bot]' }}
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ env.COVERAGE_COMMENT_ID }}


### PR DESCRIPTION
This fixes the automatic comment reporting the test-coverage for each pull request to avoid getting "null"-comments like this:
![image](https://github.com/user-attachments/assets/0a43db34-7fcd-4d91-a98a-57588255ca75)
