### PR TITLE
ci: use matrix strategy with dynamic git tag list

### DIFF
--- a/.github/workflows/update_base_images.yaml
+++ b/.github/workflows/update_base_images.yaml
@@ -9,38 +9,68 @@ jobs:
   latest-tags:
     runs-on: ubuntu-latest
     outputs:
-      main_tag: ${{ steps.main_tag.outputs.main_tag }}
-      next_tag: ${{ steps.next_tag.outputs.next_tag }}
+      latest_tags: ${{ steps.latest_tags.outputs.latest_tags }}
     steps:
       - name: Checkout sources 🔰
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Get latest main tag
-        id: main_tag
-        run: echo "main_tag=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 | sed 's/^v//')" | tee -a $GITHUB_OUTPUT
+      - name: Get latest tags
+        id: latest_tags
+        run: |
+          # The command lists the latest 10 Git tags, filtered and sorted by the following rules:
+          #
+          # * Minimum version: Only tags with a major version >= v17 are included (where the docker base image feature has been introduced)
+          # * Only one "-next" version: Displays only the latest -next.x tag, if present.
+          # * Limit Per Major Line: Shows up to 3 tags per major version.
+          # * The final output is limited to 10 tags.
+          git tag -l "v*" \
+            | sort -r -V \
+            | awk '
+              BEGIN {
+                # Flag to ensure only one "-next" version is included
+                next_used = 0
+              }
+              {
+                # Extract the major version
+                match($0, /^v([0-9]+)\./, m)
+                major = m[1]
 
-      - name: Get latest next tag
-        id: next_tag
-        run: echo "next_tag=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-next\.[0-9]+)?$' | sort -V | tail -n1 | sed 's/^v//')" | tee -a $GITHUB_OUTPUT
+                # Skip versions below v17
+                if (major < 17) {
+                  next
+                }
 
-  update-main:
+                # Check if the tag is a "-next" version
+                if ($0 ~ /-next\./) {
+                  if (next_used == 0) {
+                    # Use only the latest "-next" version and set the flag
+                    echo "Found -next version: $0"
+                    print $0
+                    next_used = 1
+                  }
+                } else {
+                  # Allow up to 3 versions per major version line
+                  if (count[major] < 3) {
+                    echo "Adding version: $0"
+                    print $0
+                    count[major]++
+                  }
+                }
+              }
+            ' \
+            | head -n 10 | tee -a $GITHUB_OUTPUT
+
+  run-for-tag:
     needs: latest-tags
     uses: ./.github/workflows/release_docker.yml
+    strategy:
+      matrix:
+        tag: ${{ fromJson(needs.latest-tags.outputs.latest_tags) }}
     with:
       release_is_published: "true"
-      release_version: ${{ needs.latest-tags.outputs.main_tag }}
-    secrets:
-      nexus_user: ${{ secrets.NEXUS_USERNAME}}
-      nexus_pass: ${{ secrets.NEXUS_PASSWORD}}
-
-  update-next:
-    needs: latest-tags
-    uses: ./.github/workflows/release_docker.yml
-    with:
-      release_is_published: "true"
-      release_version: ${{ needs.latest-tags.outputs.next_tag }}
+      release_version: ${{ matrix.tag }}
     secrets:
       nexus_user: ${{ secrets.NEXUS_USERNAME}}
       nexus_pass: ${{ secrets.NEXUS_PASSWORD}}


### PR DESCRIPTION
Uses a github workflow matrix strategy to dynamically run a "update docker base image" workflow based on a dynamic list of latest git tags.

A `git tag` command is used to filter by the following rules:

* Minimum version: Only tags with a major version >= v17 are included (where the docker base image feature has been introduced)
* Only one "-next" version: Displays only the latest -next.x tag, if present.
* Limit Per Major Line: Shows up to 3 tags per major version.
* The final output is limited to 10 tags.
