### PR TITLE
Update fullscreen wrapper

### DIFF
--- a/src/Component/FormField/JSONEditor/JSONEditor.less
+++ b/src/Component/FormField/JSONEditor/JSONEditor.less
@@ -1,5 +1,7 @@
 .json-editor {
   height: 100%;
+  display: flex;
+  flex-direction: column;
 
   .json-editor-toolbar {
     display: flex;
@@ -9,6 +11,10 @@
     padding: 2px;
     background: #fafafa;
 
+    >.fill {
+      flex: 1;
+    }
+
     > *:not(:last-child) {
       margin-right: 4px;
     }
@@ -16,6 +22,7 @@
 
   section {
     border: 1px solid #dedede;
+    flex: 1;
 
     .monaco-editor {
       min-height: 10em;

--- a/src/Component/FormField/JSONEditor/JSONEditor.tsx
+++ b/src/Component/FormField/JSONEditor/JSONEditor.tsx
@@ -7,6 +7,7 @@ import React, {
 } from 'react';
 
 import {
+  FullscreenOutlined,
   MenuUnfoldOutlined
 } from '@ant-design/icons';
 
@@ -46,7 +47,7 @@ import {
 import OpenAPIUtil from '../../../Util/OpenAPIUtil';
 
 import CopyToClipboardButton from '../../CopyToClipboardButton/CopyToClipboardButton';
-import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
+import { FullscreenWrapper } from '../../FullscreenWrapper/FullscreenWrapper';
 
 import './JSONEditor.less';
 
@@ -59,6 +60,7 @@ export interface JSONEditorProps {
   entityType: string;
   dataField: string;
   indentSize?: number;
+  fullscreenTitle?: string;
 }
 
 export const JSONEditor: React.FC<JSONEditorProps> = ({
@@ -67,6 +69,7 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
   editorProps,
   entityType,
   dataField,
+  fullscreenTitle,
   indentSize = 2
 }) => {
   const [currentValue, setCurrentValue] = useState<string | undefined>(
@@ -77,6 +80,8 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
   // don't want to trigger the onChange event on mount, so we need to keep track of whether the
   // document has been formatted initially.
   const [isFormattedInitially, setIsFormattedInitially] = useState<boolean>(false);
+
+  const [isFullScreen, setIsFullScreen] = useState<boolean>(false);
 
   const {
     t
@@ -186,13 +191,12 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
   };
 
   return (
-    <FullscreenWrapper>
-      <div
-        className="json-editor"
-      >
-        <div
-          className="json-editor-toolbar"
-        >
+    <FullscreenWrapper
+      isFullscreen={isFullScreen}
+      title={fullscreenTitle}
+    >
+      <div className="json-editor">
+        <div className="json-editor-toolbar">
           <Tooltip
             title={t('JSONEditor.formatDocumentTooltip')}
           >
@@ -204,6 +208,18 @@ export const JSONEditor: React.FC<JSONEditorProps> = ({
           <CopyToClipboardButton
             value={currentValue}
           />
+          <span className="fill"></span>
+          <Tooltip
+            title={isFullScreen
+              ? t('FullscreenWrapper.leaveFullscreen')
+              : t('FullscreenWrapper.fullscreen')
+            }
+          >
+            <Button
+              onClick={() => setTimeout(() => setIsFullScreen(!isFullScreen), 0)}
+              icon={<FullscreenOutlined />}
+            />
+          </Tooltip>
         </div>
         <Editor
           onMount={onMount}

--- a/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
+++ b/src/Component/FormField/MarkdownEditor/MarkdownEditor.tsx
@@ -1,14 +1,19 @@
 import './MarkdownEditor.less';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 
+import { FullscreenOutlined } from '@ant-design/icons';
 import MDEditor, { ICommand } from '@uiw/react-md-editor';
 
-import FullscreenWrapper from '../../FullscreenWrapper/FullscreenWrapper';
+import { Button, Tooltip } from 'antd';
+import { useTranslation } from 'react-i18next';
+
+import { FullscreenWrapper } from '../../FullscreenWrapper/FullscreenWrapper';
 
 export interface MarkdownEditorProps {
   value?: string;
   onChange?: (value?: string) => void;
+  fullscreenTitle?: string;
 }
 
 export const commandsFilter = (command: ICommand) => {
@@ -20,9 +25,15 @@ export const commandsFilter = (command: ICommand) => {
 
 export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   value,
+  fullscreenTitle,
   onChange = () => undefined
 }) => {
-  const [markdown, setMarkdown] = React.useState<string>();
+  const [markdown, setMarkdown] = useState<string>();
+  const [isFullScreen, setIsFullScreen] = useState<boolean>(false);
+
+  const {
+    t
+  } = useTranslation();
 
   useEffect(() => {
     setMarkdown(value);
@@ -34,13 +45,27 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
   };
 
   return (
-    <FullscreenWrapper>
+    <FullscreenWrapper
+      isFullscreen={false}
+      title={fullscreenTitle}
+    >
       <MDEditor
         value={markdown}
         commandsFilter={commandsFilter}
         onChange={onMarkdownChange}
         highlightEnable={false}
       />
+      <Tooltip
+        title={isFullScreen
+          ? t('FullscreenWrapper.leaveFullscreen')
+          : t('FullscreenWrapper.fullscreen')
+        }
+      >
+        <Button
+          onClick={() => setTimeout(() => setIsFullScreen(!isFullScreen), 0)}
+          icon={<FullscreenOutlined />}
+        />
+      </Tooltip>
     </FullscreenWrapper>
   );
 };

--- a/src/Component/FullscreenWrapper/FullscreenWrapper.less
+++ b/src/Component/FullscreenWrapper/FullscreenWrapper.less
@@ -1,32 +1,23 @@
-.fs-wrapper {
-  border: solid 1px #dedede;
-  border-radius: var(--ant-border-radius);
-  flex-direction: column;
-  display: flex;
-  resize: vertical;
-  overflow: hidden;
-  min-height: 10em;
-  background: #fafafa;
+.ant-modal-mask:has(+ .fullscreen-wrapper-wrapper) {
+  backdrop-filter: unset;
+}
 
-  >button {
-    min-width: 24px;
-    min-height: 24px;
-    margin: 2px;
-    align-self: end;
-  }
+.fullscreen-wrapper {
+  >div {
+    height: 100%;
 
-  &:hover {
-    border: solid 1px #40a9ff;
-  }
+    >.ant-modal-content {
+      height: 100%;
+      --header-height: calc(var(--ant-modal-header-margin-bottom) + 24px);
+      --body-height: calc(100% - var(--header-height) - var(--ant-modal-header-margin-bottom));
 
-  &:hover:active,
-  &:focus {
-    box-shadow: 0 0 0 3px rgb(24 144 255 / 20%);
-  }
+      .ant-modal-header {
+        height: var(--header-height);
+      }
 
-  &.fullscreen {
-    resize: none;
-    z-index: 999;
-    position: fixed;
+      .ant-modal-body {
+        height: var(--body-height);
+      }
+    }
   }
 }

--- a/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
@@ -131,6 +131,14 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
    * @param fieldCfg
    */
   const createFieldComponent = (fieldCfg: FieldConfig): React.ReactNode => {
+
+    const entityName = TranslationUtil.getTranslationFromConfig(generalEntityRootContext?.entityName, i18n);
+    const fieldLabel = TranslationUtil.getTranslationFromConfig(fieldCfg.label as string, i18n);
+    const name = form.getFieldValue('name');
+    const nameOrId = name || `${entityName} ${form.getFieldValue('id')}`;
+
+    const fullscreenTitle = `${nameOrId}: ${fieldLabel}`;
+
     switch (fieldCfg?.component) {
       case 'TextArea':
         return (
@@ -185,6 +193,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
           <JSONEditor
             entityType={generalEntityRootContext?.entityType || ''}
             dataField={fieldCfg.dataField}
+            fullscreenTitle={fullscreenTitle}
             {
               ...fieldCfg?.fieldProps
             }

--- a/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityForm/GeneralEntityForm.tsx
@@ -181,6 +181,7 @@ export const GeneralEntityForm: React.FC<GeneralEntityFormProps> = ({
       case 'MarkdownEditor':
         return (
           <MarkdownEditor
+            fullscreenTitle={fullscreenTitle}
             {...fieldCfg?.fieldProps}
           />
         );


### PR DESCRIPTION
This updates the `FullscreenWrapper`.

- The previous approach via CSS only was replaced with a modal based approach.
- The fullscreen state is handled via prop

## Preview

![shogun-admin-fullscreenwrapper](https://github.com/user-attachments/assets/05e2ed7e-d64d-4062-87fe-9ecccf5cb31b)
