### PR TITLE
fix: saving entities via keyboard save

### DIFF
--- a/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
+++ b/src/Component/GeneralEntity/GeneralEntityRoot/GeneralEntityRoot.tsx
@@ -428,7 +428,7 @@ export function GeneralEntityRoot<T extends BaseEntity>({
   };
 
   useHotkeys('ctrl+s', handleKeyboardSave, {
-    enableOnFormTags: ['INPUT', 'TEXTAREA', 'SELECT'],
+    enableOnFormTags: true,
     enabled: () => !saveReloadDisabled && formValid
   });
 


### PR DESCRIPTION
This enables the saving of all form tags via keyboard save.

Please review @terrestris/devs 