### PR TITLE
fix: update e2e-tests to run on the latest admin client

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,10 +1,10 @@
 FROM mcr.microsoft.com/playwright:v1.60.0-jammy
 
-WORKDIR /app
-
-RUN npm install @playwright/test@v1.36.1
-RUN npx playwright install --with-deps chromium
+COPY package.json package-lock.json ./
+RUN npm ci
 
 COPY playwright.config.ts ./
 COPY global-setup.ts ./
 COPY ./src/e2e-tests ./src/e2e-tests
+
+CMD [ "npm", "run", "e2e-tests" ]

--- a/global-setup.ts
+++ b/global-setup.ts
@@ -6,7 +6,7 @@ async function globalSetup(config: FullConfig) {
   // @ts-ignore
   process.env.ID = '20';
   // @ts-ignore
-  process.env.HOST = 'https://localhost:8080';
+  process.env.HOST = 'https://shogun.intranet.terrestris.de';
 }
 
 export default globalSetup;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ import {
 export default defineConfig({
   // @ts-ignore
   globalSetup: require.resolve('./global-setup.ts'),
-  testDir: './e2e-tests',
+  testDir: './src/e2e-tests',
   timeout: 30 * 1000,
   expect: {
     timeout: 30 * 1000
@@ -21,7 +21,7 @@ export default defineConfig({
   }]],
   use: {
     // @ts-ignore
-    headless: false,
+    headless: true,
     baseURL: process.env.HOST,
     actionTimeout: 30000,
     trace: 'on-first-retry',

--- a/src/e2e-tests/applicationConfig.spec.ts
+++ b/src/e2e-tests/applicationConfig.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import {
   deleteAllRowsWithText,
   findElementInPaginatedTable,
+  highlight,
   login,
   switchLanguage,
   writeToEditor,
@@ -72,7 +73,8 @@ export const applicationConfig = async (page: any) => {
   await expect(
     page.getByText('Application successfully saved').first()
   ).toBeVisible();
-
+  await highlight(page.getByText('Application successfully saved').first());
+  
   await page.getByRole('button', { name: 'fullscreen' }).nth(1).click();
   await expect(page.locator('.monaco-editor').first()).toBeVisible();
   const jsonEditor = await page.locator('.view-line').first();
@@ -108,6 +110,8 @@ export const applicationConfig = async (page: any) => {
   await expect(
     page.getByText('Application successfully saved').first()
   ).toBeVisible();
+  await highlight(page.getByText('Application successfully saved').first());
+
   await page.locator(".ant-notification-notice-close").click();
   await page.getByRole('button', { name: 'fullscreen-exit' }).click();
   await expect(page.getByTitle(/^Configure Tools$/)).toBeVisible();
@@ -134,6 +138,7 @@ export const applicationConfig = async (page: any) => {
 
   await page.getByRole('button', { name: 'save Save Application' }).click();
   await expect(page.getByText('Application successfully saved')).toBeVisible();
+  await highlight(page.getByText('Application successfully saved').first());
   await page.getByLabel('Close', { exact: true }).first().click();
 
   let pageNumberApp = 2;
@@ -149,6 +154,7 @@ export const applicationConfig = async (page: any) => {
         })
         .first();
       await targetRow.waitFor({ state: 'visible', timeout: 10000 });
+      await highlight(targetRow);
 
       const rowContent = await targetRow.innerText();
       applicationID = rowContent.match(/\d+/)?.[0];
@@ -172,12 +178,15 @@ export const applicationConfig = async (page: any) => {
 
   await page.goto(`/client/?applicationId=${applicationID}`);
   await expect(page.locator('#map')).toBeVisible();
+  await highlight(page.locator('#map'));
   await expect(page.getByText('Messen')).not.toBeVisible();
   await expect(page.getByText('Karten').first()).toBeVisible();
+  await highlight(page.getByText('Karten').first());
   await page
     .getByRole('button', { name: 'collapsed Karten', exact: true })
     .click();
   await expect(page.getByText('Test Layer')).toBeVisible();
+  await highlight(page.getByText('Test Layer'));
 
   await page.goto('/admin/portal');
   await page.waitForSelector('.header-logo', {

--- a/src/e2e-tests/applicationConfig.spec.ts
+++ b/src/e2e-tests/applicationConfig.spec.ts
@@ -57,14 +57,15 @@ export const applicationConfig = async (page: any) => {
   }
   await lineElement.click({ force: true });
 
-  const textLocation = page.locator('.view-lines > div:nth-child(26)');
+  const textLocation = page.locator('.view-lines > div:nth-last-child(2)').first();
 
-  writeToEditor(page, textLocation, `, 
+  await writeToEditor(page, textLocation, `, 
     "defaultLanguage": "de"`);
-  const editedElement = page.locator('div').filter({
-    hasText: `, 
-    "defaultLanguage": "de"` }).first();
-  await editedElement.waitFor({ state: 'visible', timeout: 10000 });
+  await expect(
+    page.locator('.monaco-editor .view-line').filter({
+      hasText: /"defaultLanguage":\s*"de"/,
+    }).first()
+  ).toBeVisible({ timeout: 10000 });
   await page.waitForLoadState('networkidle');
 
   await page.getByRole('button', { name: 'save Save Application' }).click({ force: true });

--- a/src/e2e-tests/applicationsPage.spec.ts
+++ b/src/e2e-tests/applicationsPage.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 
 import { expect } from '@playwright/test';
-import { deleteAllRowsWithText, login, switchLanguage } from './helpers';
+import { deleteAllRowsWithText, highlight, login, switchLanguage } from './helpers';
 
 export const applicationsPage = async (page: any) => {
   await page.waitForLoadState('networkidle');
@@ -11,6 +11,9 @@ export const applicationsPage = async (page: any) => {
   await expect(
     page.getByRole('link', { name: 'bank Applications … that move' })
   ).toBeVisible();
+  await highlight(
+    page.getByRole('link', { name: 'bank Applications … that move' }).first()
+  );
   const applicationsNumberText = await page
     .getByRole('link', { name: ' Applications' })
     .innerText();
@@ -20,6 +23,11 @@ export const applicationsPage = async (page: any) => {
       hasText: applicationsNumber,
     }).first()
   ).toBeVisible();
+  await highlight(
+    page.locator('.ant-statistic-content-value').filter({
+      hasText: applicationsNumber,
+    }).first()
+  );
   await page
     .getByRole('menuitem', { name: 'bank Application' })
     .locator('span')
@@ -27,14 +35,23 @@ export const applicationsPage = async (page: any) => {
     .click();
 
   await expect(page.locator('.ant-table-container')).toBeVisible();
+  await highlight(page.locator('.ant-table-container').first());
   await expect(page.getByLabel(/^ID$/)).toBeVisible();
+  await highlight(page.getByLabel(/^ID$/).first());
   await expect(page.getByText(/^Name$/)).toBeVisible();
+  await highlight(page.getByText(/^Name$/).first());
   await expect(page.getByText(/^Last edited on$/)).toBeVisible();
+  await highlight(page.getByText(/^Last edited on$/).first());
   await expect(page.getByText(/^Link to application$/)).toBeVisible();
+  await highlight(page.getByText(/^Link to application$/).first());
   await expect(page.getByLabel('sync').locator('svg')).toBeVisible();
+  await highlight(page.getByLabel('sync').locator('svg').first());
   await expect(
     page.getByRole('button', { name: 'form Create Application' })
   ).toBeVisible();
+  await highlight(
+    page.getByRole('button', { name: 'form Create Application' }).first()
+  );
 
   const rowCount = await page.locator('.ant-table-row').count();
   if (applicationsNumber < 20) {
@@ -45,21 +62,33 @@ export const applicationsPage = async (page: any) => {
 
   await page.getByRole('button', { name: 'form Create Application' }).click();
   await expect(page.getByText(/^Identifier$/)).toBeVisible();
+  await highlight(page.getByText(/^Identifier$/).first());
   await expect(page.getByText(/^Created at$/)).toBeVisible();
+  await highlight(page.getByText(/^Created at$/).first());
   await expect(page.getByText(/^Status of work$/)).toBeVisible();
+  await highlight(page.getByText(/^Status of work$/).first());
   await expect(page.getByText(/^Public application$/)).toBeVisible();
+  await highlight(page.getByText(/^Public application$/).first());
   await expect(page.getByText(/^Client configuration$/)).toBeVisible();
+  await highlight(page.getByText(/^Client configuration$/).first());
   await expect(page.getByTitle(/^Layertree$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Layertree$/).first());
   await expect(page.getByTitle(/^Layer configuration$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Layer configuration$/).first());
   await expect(page.getByTitle(/^Configure Tools$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Configure Tools$/).first());
   await expect(page.getByTitle(/^User permissions$/)).toBeVisible();
+  await highlight(page.getByTitle(/^User permissions$/).first());
   await expect(page.getByTitle(/^Group permissions$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Group permissions$/).first());
   await expect(page.getByTitle(/^Role permissions$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Role permissions$/).first());
 
   await page.getByRole('button', { name: 'form Create Application' }).click();
   await page.getByLabel('Name').nth(1).fill('Test Application Playwright');
   await page.getByRole('button', { name: 'save Save Application' }).click();
   await expect(page.getByText('Application successfully saved')).toBeVisible();
+  await highlight(page.getByText('Application successfully saved').first());
   await page.getByLabel('Close', { exact: true }).click();
   await page
     .getByRole('menuitem', { name: 'bank Application' })
@@ -76,6 +105,7 @@ export const applicationsPage = async (page: any) => {
       hasText: 'Test Application Playwright',
     })
     .first();
+  await highlight(targetRow);
   const rowContent = await targetRow.innerText();
   const applicationID = rowContent.match(/\d+/)?.[0];
 
@@ -119,6 +149,7 @@ export const applicationsPage = async (page: any) => {
     .fill('Test Application Playwright EDITED');
   await page.getByRole('button', { name: 'save Save Application' }).click();
   await expect(page.getByText('Application successfully saved')).toBeVisible();
+  await highlight(page.getByText('Application successfully saved').first());
   await page.getByLabel('Close', { exact: true }).click();
   await expect(
     page.getByText('Test Application Playwright EDITED').first()
@@ -126,6 +157,7 @@ export const applicationsPage = async (page: any) => {
 
   await page.goto(`/client/?applicationId=${applicationID}`);
   await expect(page.locator('#map')).toBeVisible();
+  await highlight(page.locator('#map'));
 
   await page.goto('/admin/portal');
   await page

--- a/src/e2e-tests/globalConfig.spec.ts
+++ b/src/e2e-tests/globalConfig.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login, switchLanguage } from './helpers';
+import { highlight, login, switchLanguage } from './helpers';
 
 
 export const globalConfig = async (page: any) => {
@@ -12,6 +12,7 @@ export const globalConfig = async (page: any) => {
   await page.getByText('Global').click();
 
   await expect(page.getByTitle(/^Configuration$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Configuration$/).first());
   await expect(page.getByTitle(/^… that guide the world$/)).toBeVisible();
   await page.getByRole('button', { name: 'clear Clear cache' }).click();
   await expect(

--- a/src/e2e-tests/header.spec.ts
+++ b/src/e2e-tests/header.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login, switchLanguage } from './helpers';
+import { highlight, login, switchLanguage } from './helpers';
 
 
 export const header = async (page: any) => {
@@ -10,6 +10,7 @@ export const header = async (page: any) => {
   });
   const logo = await page.locator('.header-logo');
   await expect(logo).toBeVisible();
+  await highlight(logo);
   await expect(page.locator('.language-select')).toBeVisible();
   await expect(page.locator('.language-select')).toBeVisible();
   await switchLanguage(page, 'EN');
@@ -19,31 +20,47 @@ export const header = async (page: any) => {
     timeout: 60000,
   });
   await expect(page.locator('.user-menu')).toBeVisible();
+  await highlight(page.locator('.user-menu').first());
   await expect(page.locator('.portal')).toBeVisible();
+  await highlight(page.locator('.portal').first());
 
   await page.locator('.user-menu').click();
   await expect(page.getByText(/^Profile settings$/)).toBeVisible();
+  await highlight(page.getByText(/^Profile settings$/).first());
   await expect(page.getByText(/^Info$/)).toBeVisible();
+  await highlight(page.getByText(/^Info$/).first());
   await expect(page.getByText(/^Logout$/)).toBeVisible();
+  await highlight(page.getByText(/^Logout$/).first());
 
   await page.getByText('Profile settings').click();
   const settingsUrl = await page.url();
   await expect(settingsUrl).toContain('/auth/realms/');
   await expect(page.getByTestId('page-heading')).toBeVisible();
+  await highlight(page.getByTestId('page-heading').first());
   await expect(page.getByText('Manage your basic information')).toBeVisible();
+  await highlight(page.getByText('Manage your basic information').first());
   await expect(page.getByRole('heading', { name: 'General' })).toBeVisible();
+  await highlight(page.getByRole('heading', { name: 'General' }).first());
   await expect(page.getByText('Username')).toBeVisible();
+  await highlight(page.getByText('Username').first());
   await expect(page.getByText('Email')).toBeVisible();
+  await highlight(page.getByText('Email').first());
   await expect(page.getByText('First name')).toBeVisible();
+  await highlight(page.getByText('First name').first());
   await expect(page.getByText('Last name')).toBeVisible();
+  await highlight(page.getByText('Last name').first());
 
   await page.goto('/admin/portal');
   await page.locator('.user-menu').click();
   await page.getByText('Info').click();
   await expect(page.getByLabel('About').locator('img')).toBeVisible();
+  await highlight(page.getByLabel('About').locator('img').first());
   await expect(page.getByText('About')).toBeVisible();
+  await highlight(page.getByText('About').first());
   await expect(page.getByText('Admin version')).toBeVisible();
+  await highlight(page.getByText('Admin version').first());
   await expect(page.getByText('Backend version')).toBeVisible();
+  await highlight(page.getByText('Backend version').first());
   await page.getByLabel('Close', { exact: true }).first().click();
   await expect(page.getByLabel('About').locator('img')).not.toBeVisible();
 
@@ -52,6 +69,7 @@ export const header = async (page: any) => {
   await expect(
     page.getByRole('heading', { name: 'Sign in to your account' })
   ).toBeVisible();
+  await highlight(page.getByRole('heading', { name: 'Sign in to your account' }).first())
   const loginUrl = await page.url();
   await expect(loginUrl).toContain('/auth/realms/');
 };

--- a/src/e2e-tests/helpers.ts
+++ b/src/e2e-tests/helpers.ts
@@ -1,3 +1,5 @@
+import { Locator } from '@playwright/test';
+
 export const login = async (
   page: any,
   username: string,
@@ -148,3 +150,15 @@ export const writeToEditor = async (page: any, textLocation: any, inputText: str
 
   await page.keyboard.press('Control+V');
 };
+
+export async function highlight(locator: Locator) {
+  await locator.evaluate((el) => {
+    el.style.outline = '3px solid yellow';
+    el.style.backgroundColor = 'yellow';
+    setTimeout(() => {
+      el.style.outline = '';
+      el.style.backgroundColor = '';
+    }, 800);
+  });
+  await new Promise(resolve => setTimeout(resolve, 2000));
+}

--- a/src/e2e-tests/helpers.ts
+++ b/src/e2e-tests/helpers.ts
@@ -117,6 +117,10 @@ export const deleteAllRowsWithText = async (page: any, text: string) => {
           await page.waitForSelector('.ant-notification-notice', {
             state: 'visible',
           });
+          await page.waitForSelector('.ant-notification-notice [data-icon="close"]', {
+            state: 'visible',
+          });
+          await page.locator('.ant-notification-notice [data-icon="close"]').first().click();
           await page.waitForLoadState('networkidle');
         }
       }

--- a/src/e2e-tests/landingPage.spec.ts
+++ b/src/e2e-tests/landingPage.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login, switchLanguage } from './helpers';
+import { highlight, login, switchLanguage } from './helpers';
 
 
 export const landingPage = async (page: any) => {
@@ -18,8 +18,10 @@ export const landingPage = async (page: any) => {
     timeout: 60000,
   });
   await expect(page.locator('.user-menu')).toBeVisible();
+  await highlight(page.locator('.user-menu').first());
 
   await expect(page.locator('.portal')).toBeVisible();
+  await highlight(page.locator('.portal').first());
 
   const menu = await page.locator('.menu');
   await expect(menu).toBeVisible();
@@ -46,10 +48,13 @@ export const landingPage = async (page: any) => {
   await expect(
     page.locator('div').filter({ hasText: /^Applications$/ })
   ).toBeVisible();
+  await highlight(page.locator('div').filter({ hasText: /^Applications$/ }).first());
   await expect(
     page.locator('div').filter({ hasText: /^Layers$/ })
   ).toBeVisible();
+  await highlight(page.locator('div').filter({ hasText: /^Layers$/ }).first());
   await expect(page.locator('div').filter({ hasText: /^User$/ })).toBeVisible();
+  await highlight(page.locator('div').filter({ hasText: /^User$/ }).first());
 };
 
 test.beforeEach(async ({ page }) => {

--- a/src/e2e-tests/languageSelector.spec.ts
+++ b/src/e2e-tests/languageSelector.spec.ts
@@ -22,7 +22,7 @@ export const languageSelector = async (page: any) => {
   ).toBeVisible();
   await expect(
     page.locator(".ant-menu-title-content").filter({
-      hasText: initialTitle.toString(),
+      hasText: new RegExp(`^${initialTitle.toString().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`)
     })
   ).toBeVisible();
 
@@ -44,7 +44,7 @@ export const languageSelector = async (page: any) => {
   ).toBeVisible();
   await expect(
     page.locator(".ant-menu-title-content").filter({
-      hasText: changedTitle.toString(),
+      hasText: new RegExp(`^${changedTitle.toString().replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`)
     })
   ).toBeVisible();
 

--- a/src/e2e-tests/languageSelector.spec.ts
+++ b/src/e2e-tests/languageSelector.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { login } from "./helpers";
+import { highlight, login } from "./helpers";
 
 
 export const languageSelector = async (page: any) => {
@@ -36,6 +36,8 @@ export const languageSelector = async (page: any) => {
     .locator(".ant-menu-title-content")
     .first()
     .innerText();
+
+  await highlight(page.locator(".language-select").first());
 
   await expect(
     page.locator(".language-select").filter({

--- a/src/e2e-tests/layerConfig.spec.ts
+++ b/src/e2e-tests/layerConfig.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { deleteAllRowsWithText, findElementInPaginatedTable, login, switchLanguage, writeToEditor } from './helpers';
+import { deleteAllRowsWithText, findElementInPaginatedTable, highlight, login, switchLanguage, writeToEditor } from './helpers';
 
 
 export const layerConfig = async (page: any) => {
@@ -54,7 +54,7 @@ export const layerConfig = async (page: any) => {
     throw new Error('The element is not clickable.');
   }
 
-  await jsonEditor.click({force: true});
+  await jsonEditor.click({ force: true });
   await page.waitForLoadState('networkidle');
   const jsonContent = `{
     "title": "root",
@@ -78,6 +78,7 @@ export const layerConfig = async (page: any) => {
   await expect(
     page.getByText('Application successfully saved').first()
   ).toBeVisible();
+  await highlight(page.getByText('Application successfully saved').first());
   await page.locator('.ant-notification-notice-close').click();
   await expect(page.getByTitle(/^Configure Tools$/)).toBeVisible();
 
@@ -87,15 +88,18 @@ export const layerConfig = async (page: any) => {
       hasText: 'Test layerConfig Application Playwright',
     })
     .first();
+  await highlight(targetRow);
   const rowContent = await targetRow.innerText();
   const applicationID = rowContent.match(/\d+/)?.[0];
 
   await page.goto(`/client/?applicationId=${applicationID}`);
   await expect(page.locator('#map')).toBeVisible();
+  await highlight(page.locator('#map').first());
   await page
     .getByRole('button', { name: 'collapsed Maps', exact: true })
     .click();
   await expect(page.getByText('Test Layer', { exact: true })).toBeVisible();
+  await highlight(page.getByText('Test Layer', { exact: true }).first());
 
   await page.goto('/admin/portal');
   await page

--- a/src/e2e-tests/layersPage.spec.ts
+++ b/src/e2e-tests/layersPage.spec.ts
@@ -144,11 +144,6 @@ export const layersPage = async (page: any) => {
   await expect(parseInt(firstIDUpdated, 10)).toBeGreaterThan(
     parseInt(secondIDUpdated, 10)
   );
-
-  await page.getByRole('columnheader', { name: 'Type' }).locator('div').click();
-  const firstRowType = await page.locator('.ant-table-row').first();
-  const firstRowTypeContent = await firstRowType.innerText();
-  await expect(firstRowTypeContent).toContain('WMTS');
 };
 
 test.beforeEach(async ({ page }) => {

--- a/src/e2e-tests/layersPage.spec.ts
+++ b/src/e2e-tests/layersPage.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { deleteAllRowsWithText, login, switchLanguage } from './helpers';
+import { deleteAllRowsWithText, highlight, login, switchLanguage } from './helpers';
 
 
 export const layersPage = async (page: any) => {
@@ -22,28 +22,43 @@ export const layersPage = async (page: any) => {
   await page.getByText('Layers', { exact: true }).first().click();
 
   await expect(page.locator('.ant-table-container')).toBeVisible();
+  await highlight(page.locator('.ant-table-container').first());
   await expect(page.getByLabel(/^ID$/)).toBeVisible();
+  await highlight(page.getByLabel(/^ID$/).first());
   await expect(page.getByText(/^Name$/)).toBeVisible();
+  await highlight(page.getByText(/^Name$/).first());
   await expect(page.getByText(/^Type$/)).toBeVisible();
+  await highlight(page.getByText(/^Type$/).first());
   await expect(
     page.getByRole('button', { name: 'form Create Layer' })
   ).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'form Create Layer' }).first());
   await expect(page.getByLabel('appstore-add')).toBeVisible();
+  await highlight(page.getByLabel('appstore-add').first());
 
   await expect(page.getByText('Total:')).toBeVisible();
+  await highlight(page.getByText('Total:').first());
   const totalLayersNumberText = await page.getByText('Total:').innerText();
   const totalLayersNumber = totalLayersNumberText.match(/\d+/)?.[0];
   await expect(totalLayersNumber).toBe(layersNumber);
 
   await page.getByRole('button', { name: 'form Create Layer' }).click();
   await expect(page.getByText(/^Created at$/)).toBeVisible();
+  await highlight(page.getByText(/^Created at$/).first());
   await expect(page.getByText(/^Last edited on$/)).toBeVisible();
+  await highlight(page.getByText(/^Last edited on$/).first());
   await expect(page.getByText(/^Public layer$/)).toBeVisible();
+  await highlight(page.getByText(/^Public layer$/).first());
   await expect(page.getByTitle(/^Configuration$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Configuration$/).first());
   await expect(page.getByTitle(/^Datasource$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Datasource$/).first());
   await expect(page.getByTitle(/^User permissions$/)).toBeVisible();
+  await highlight(page.getByTitle(/^User permissions$/).first());
   await expect(page.getByTitle(/^Group permissions$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Group permissions$/).first());
   await expect(page.getByTitle(/^Role permissions$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Role permissions$/).first());
 
   await page
     .locator('.ant-select-selection-item')
@@ -52,21 +67,34 @@ export const layersPage = async (page: any) => {
   await expect(
     page.locator('.ant-select-item-option-content').filter({ hasText: /^WFS$/ })
   ).toBeVisible();
+  await highlight(
+    page.locator('.ant-select-item-option-content').filter({ hasText: /^WFS$/ }).first()
+  );
   await expect(
     page.locator('.ant-select-item-option-content').filter({ hasText: /^WMS$/ })
   ).toBeVisible();
+  await highlight(
+    page.locator('.ant-select-item-option-content').filter({ hasText: /^WMS$/ }).first()
+  );
   await expect(
     page
       .locator('.ant-select-item-option-content')
       .filter({ hasText: /^WMSTIME$/ })
   ).toBeVisible();
+  await highlight(
+    page.locator('.ant-select-item-option-content').filter({ hasText: /^WMSTIME$/ }).first()
+  );
   await expect(
     page.locator('.ant-select-item-option-content').filter({ hasText: /^XYZ$/ })
   ).toBeVisible();
+  await highlight(
+    page.locator('.ant-select-item-option-content').filter({ hasText: /^XYZ$/ }).first()
+  );
 
   await page.getByLabel('Name').nth(1).fill('Test Layer Playwright');
   await page.getByRole('button', { name: 'save Save Layer' }).click();
   await expect(page.getByText('Layer successfully saved')).toBeVisible();
+  await highlight(page.getByText('Layer successfully saved').first());
   await page.getByLabel('Close', { exact: true }).first().click();
   await page.getByText('Layers', { exact: true }).first().click();
 
@@ -97,9 +125,13 @@ export const layersPage = async (page: any) => {
   await expect(
     page.getByText('Layer preview (Test Layer Playwright)')
   ).toBeVisible();
+  await highlight(page.getByText('Layer preview (Test Layer Playwright)').first());
   await expect(page.locator('.ol-layer')).toBeVisible();
+  await highlight(page.locator('.ol-layer').first());
   await expect(page.getByRole('button', { name: '+' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: '+' }).first());
   await expect(page.getByRole('button', { name: '–' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: '–' }).first());
   await page.getByLabel('Close', { exact: true }).first().click();
 
   await page
@@ -114,6 +146,7 @@ export const layersPage = async (page: any) => {
   await page.getByTitle('Name').first().fill('Test Layer Playwright EDITED');
   await page.getByRole('button', { name: 'save Save Layer' }).click();
   await expect(page.getByText('Layer successfully saved')).toBeVisible();
+  await highlight(page.getByText('Layer successfully saved').first());
   await page.getByText('Layers', { exact: true }).first().click();
   await expect(
     page.getByText('Test Layer Playwright EDITED').first()
@@ -126,9 +159,11 @@ export const layersPage = async (page: any) => {
   await page.getByText('ID').first().click();
   await page.waitForTimeout(1000);
   const firstRow = await page.locator('.ant-table-row').first();
+  await highlight(firstRow);
   const firstRowContent = await firstRow.innerText();
   const firstID = firstRowContent.match(/\d+/)?.[0];
   const secondRow = await page.locator('.ant-table-row').nth(1);
+  await highlight(secondRow);
   const secondRowContent = await secondRow.innerText();
   const secondID = secondRowContent.match(/\d+/)?.[0];
   await expect(parseInt(secondID, 10)).toBeGreaterThan(parseInt(firstID, 10));
@@ -141,6 +176,8 @@ export const layersPage = async (page: any) => {
   const secondRowUpdated = await page.locator('.ant-table-row').nth(1);
   const secondRowContentUpdated = await secondRowUpdated.innerText();
   const secondIDUpdated = secondRowContentUpdated.match(/\d+/)?.[0];
+  await highlight(firstRowUpdated);
+  await highlight(secondRowUpdated);
   await expect(parseInt(firstIDUpdated, 10)).toBeGreaterThan(
     parseInt(secondIDUpdated, 10)
   );

--- a/src/e2e-tests/logs.spec.ts
+++ b/src/e2e-tests/logs.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login, switchLanguage } from './helpers';
+import { highlight, login, switchLanguage } from './helpers';
 
 
 export const logs = async (page: any) => {
@@ -12,9 +12,13 @@ export const logs = async (page: any) => {
   await page.getByText('Logs').click();
 
   await expect(page.getByTitle(/^Logs$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Logs$/).first());
   await expect(page.getByTitle(/^… that explain the world$/)).toBeVisible();
+  await highlight(page.getByTitle(/^… that explain the world$/).first());
   await expect(page.getByRole('button', { name: 'Refresh' })).toBeVisible();
+  await highlight(page.getByRole('button', { name: 'Refresh' }).first());
   await expect(page.getByRole('switch')).toBeVisible();
+  await highlight(page.getByRole('switch').first());
 
   const logTextElement = page.locator('.log-container');
   await expect(logTextElement).toBeVisible();

--- a/src/e2e-tests/metrics.spec.ts
+++ b/src/e2e-tests/metrics.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login, switchLanguage } from './helpers';
+import { highlight, login, switchLanguage } from './helpers';
 
 
 export const metrics = async (page: any) => {
@@ -12,39 +12,52 @@ export const metrics = async (page: any) => {
   await page.getByText('Metrics').click();
 
   await expect(page.getByTitle(/^Metrics$/)).toBeVisible();
+  await highlight(page.getByTitle(/^Metrics$/).first());
   await expect(page.getByTitle(/^… that measure the world$/)).toBeVisible();
+  await highlight(page.getByTitle(/^… that measure the world$/).first());
   await expect(page.locator('.metrics-card-container')).toBeVisible();
+  await highlight(page.locator('.metrics-card-container').first());
   await expect(
     page.locator('#app').getByText('Current number of active')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('Current number of active').first());
   await expect(
     page.locator('#app').getByText('The current number of live')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('The current number of live').first());
   await expect(
     page.locator('#app').getByText('The amount of used memory')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('The amount of used memory').first());
   await expect(
     page.locator('#app').getByText('The "recent cpu usage" of')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('The "recent cpu usage" of').first());
   await expect(
     page.locator('#app').getByText('The uptime of the Java')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('The uptime of the Java').first());
   await expect(
     page.locator('#app').getByText('The number of processors')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('The number of processors').first());
   await expect(
     page.locator('#app').getByText('The "recent cpu usage" of')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('The "recent cpu usage" of').first());
   await expect(
     page.locator('#app').getByText('Start time of the process')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('Start time of the process').first());
   await expect(
     page.locator('#app').getByText('The sum of the number of')
   ).toBeVisible();
+  await highlight(page.locator('#app').getByText('The sum of the number').first());
 
   const statisticElement = page.locator(
     'div:nth-child(3) > div:nth-child(2) > div > div > div > div.ant-statistic-content > span.ant-statistic-content-value > span'
   );
+  await highlight(statisticElement.first());
   const initialText = await statisticElement.innerText();
   await page.waitForTimeout(5000);
   await page

--- a/src/e2e-tests/paging.spec.ts
+++ b/src/e2e-tests/paging.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login, switchLanguage } from './helpers';
+import { highlight, login, switchLanguage } from './helpers';
 
 
 export const paging = async (page: any) => {
@@ -14,6 +14,7 @@ export const paging = async (page: any) => {
   await expect(
     page.getByRole('link', { name: 'appstore Layers … that move' })
   ).toBeVisible();
+  await highlight(page.getByRole('link', { name: 'appstore Layers … that move' }).first());
   const layersNumberText = await page
     .getByRole('link', { name: ' Layers' })
     .innerText();
@@ -23,6 +24,9 @@ export const paging = async (page: any) => {
       hasText: layersNumber,
     })
   ).toBeVisible();
+  await highlight(page.locator('.ant-statistic-content-value').filter({
+    hasText: layersNumber,
+  }).first());
   await page.getByText('Layers', { exact: true }).first().click();
 
   await page.getByText('/ Page').click();
@@ -34,7 +38,7 @@ export const paging = async (page: any) => {
     'ul.ant-pagination li.ant-pagination-item'
   ).last();
   const lastPageNumber = parseInt(await lastPageButton.innerText());
-
+  await highlight(lastPageButton);
   await expect(lastPageNumber).toBe(expectedPageCount);
 
   await page.getByText('Layers', { exact: true }).first().click();
@@ -45,6 +49,7 @@ export const paging = async (page: any) => {
   const paginationItems2 = await page.locator(
     'ul.ant-pagination li.ant-pagination-item'
   );
+  await highlight(paginationItems2.first());
   const pageCount2 = await paginationItems2.count();
 
   await expect(pageCount2).toBe(expectedPageCount);
@@ -58,6 +63,7 @@ export const paging = async (page: any) => {
   await firstPageButton.click();
 
   await expect(page.getByRole('button', { name: 'left' })).toBeDisabled();
+  await highlight(firstPageButton);
 };
 
 test.beforeEach(async ({ page }) => {

--- a/src/e2e-tests/smoke.spec.ts
+++ b/src/e2e-tests/smoke.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { switchLanguage } from './helpers';
+import { highlight, switchLanguage } from './helpers';
 
 test.describe('Frontend Smoke Checks', () => {
   test.use({ storageState: 'playwright/.auth/admin.json' });
@@ -20,8 +20,10 @@ test.describe('Frontend Smoke Checks', () => {
     await expect(
       page.getByRole('button', { name: 'form Create Layer' })
     ).toBeVisible();
+    await highlight(page.getByRole('button', { name: 'form Create Layer' }).first());
     await page.getByRole('button', { name: 'form Create Layer' }).click();
     await expect(page.getByLabel('Name').nth(1)).toBeVisible();
+    await highlight(page.getByLabel('Name').nth(1).first());
   });
 
   test('Applications page loads', async ({ page }) => {
@@ -29,10 +31,12 @@ test.describe('Frontend Smoke Checks', () => {
     await expect(
       page.getByRole('button', { name: 'form Create Application' })
     ).toBeVisible();
+    await highlight(page.getByRole('button', { name: 'form Create Application' }).first());
   });
 
   test('Configuration page loads', async ({ page }) => {
     await page.getByText('Configuration', { exact: true }).first().click();
     await expect(page.getByText('Global')).toBeVisible();
+    await highlight(page.getByText('Global').first());
   });
 });

--- a/src/e2e-tests/userMenu.spec.ts
+++ b/src/e2e-tests/userMenu.spec.ts
@@ -1,7 +1,7 @@
 import { test } from '@playwright/test';
 
 import { expect } from '@playwright/test';
-import { login } from './helpers';
+import { highlight, login } from './helpers';
 
 export const userMenu = async (page: any) => {
   await page.waitForLoadState('networkidle');
@@ -13,6 +13,7 @@ export const userMenu = async (page: any) => {
 
   const image = page.locator('.userimage').locator('img');
   await expect(image).toBeVisible();
+  await highlight(image.first());
   const width = await image.evaluate((img: any) => img.naturalWidth);
   const height = await image.evaluate((img: any) => img.naturalHeight);
   const aspectRatio = width / height;
@@ -23,7 +24,9 @@ export const userMenu = async (page: any) => {
   await page.locator('.user-menu').click();
   const displayedUsername = await page.locator('.user-name');
   await expect(displayedUsername).toBeVisible();
+  await highlight(displayedUsername.first());
   await expect(page.getByRole('menuitem').first()).toBeVisible();
+  await highlight(page.getByRole('menuitem').first());
 
   await page.getByText('Info', { exact: true }).click();
   const display = await page
@@ -34,9 +37,11 @@ export const userMenu = async (page: any) => {
 
   await page.locator('.user-menu').click();
   await expect(page.locator('.user-name')).toBeVisible();
+  await highlight(page.locator('.user-name').first());
   await page.getByRole('menuitem', { name: 'setting' }).click();
   await expect(page).toHaveURL(/auth/);
   await expect(page.getByText('Manage your basic information')).toBeVisible();
+  await highlight(page.getByText('Manage your basic information').first());
   await page.getByText('Back to shogun-admin').click();
   await page.waitForTimeout(3000);
 

--- a/src/e2e-tests/userPermissions.spec.ts
+++ b/src/e2e-tests/userPermissions.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { deleteAllRowsWithText, login, switchLanguage } from './helpers';
+import { deleteAllRowsWithText, highlight, login, switchLanguage } from './helpers';
 
 
 export const userPermissions = async (page: any) => {
@@ -10,6 +10,9 @@ export const userPermissions = async (page: any) => {
   await expect(
     page.getByRole('link', { name: 'bank Applications … that move' })
   ).toBeVisible();
+  await highlight(
+    page.getByRole('link', { name: 'bank Applications … that move' }).first()
+  );
   await page
     .getByRole('menuitem', { name: 'bank Application' })
     .locator('span')
@@ -22,6 +25,7 @@ export const userPermissions = async (page: any) => {
     .fill('Test Application userPermission Playwright');
   await page.getByRole('button', { name: 'save Save Application' }).click();
   await expect(page.getByText('Application successfully saved')).toBeVisible();
+  await highlight(page.getByText('Application successfully saved').first());
 
   await page.getByRole('button', { name: 'plus' }).nth(2).click();
   await page
@@ -34,6 +38,7 @@ export const userPermissions = async (page: any) => {
   await page.getByRole('combobox', { name: 'Role name' }).press('Enter');
   await page.getByRole('button', { name: 'OK' }).click();
   await expect(page.getByText('Please enter Permission')).toBeVisible();
+  await highlight(page.getByText('Please enter Permission').first());
   await page.getByRole('combobox', { name: 'Permission' }).click();
   await page.getByText('Read', { exact: true }).click();
   await page.getByRole('button', { name: 'OK' }).click();


### PR DESCRIPTION
This updates the e2e-tests for the latest version of the admin client.
Also, the tests now run on the test server ('https://shogun.intranet.terrestris.de') and are thus no longer dependent on a running local setup.