### PR TITLE
Disable lazy compilation

### DIFF
--- a/rspack.dev.js
+++ b/rspack.dev.js
@@ -26,5 +26,6 @@ module.exports = merge(common, {
   },
   plugins: [
     new ReactRefreshPlugin()
-  ]
+  ],
+  lazyCompilation: false
 });


### PR DESCRIPTION
The lazy compilation interferes with other running instances of rspack in the local development setup. This suggests to actually disable it.

Please review @terrestris/devs.